### PR TITLE
[misc] add support for node 7+

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -45,7 +45,7 @@ io.configure ->
 	# gzip uses a Node 0.8.x method of calling the gzip program which
 	# doesn't work with 0.6.x
 	#io.enable('browser client gzip')
-	io.set('transports', ['websocket', 'flashsocket', 'htmlfile', 'xhr-polling', 'jsonp-polling'])
+	io.set('transports', ['websocket', 'htmlfile', 'xhr-polling', 'jsonp-polling'])
 	io.set('log level', 1)
 
 app.get "/", (req, res, next) ->

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1560,9 +1560,9 @@
       "dev": true
     },
     "socket.io": {
-      "version": "0.9.16",
-      "from": "socket.io@0.9.16",
-      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.16.tgz",
+      "version": "0.9.19",
+      "from": "socket.io@0.9.19",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-0.9.19.tgz",
       "dependencies": {
         "redis": {
           "version": "0.7.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "request": "^2.88.0",
     "session.socket.io": "^0.1.6",
     "settings-sharelatex": "^1.1.0",
-    "socket.io": "0.9.16",
+    "socket.io": "^0.9.19",
     "socket.io-client": "^0.9.16"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds support for node version 7 and above.

`process.EventEmitter` has been deprecated in node6 and was removed in node7. It is still available via the events lib. The `socket.io` release `0.9.18` includes an incomplete patch for this deprecation [1], `0.9.19` fixes the patch.

`socket.io` can support flash clients. These may request a policy file, which is provided by a package that has a similar usage of the `EventEmitter`.
I could not find any flash in the web-app, removing the transport seems to be straight forward then. 

---
[1] See the upstream PR https://github.com/socketio/socket.io/pull/2790