### PR TITLE
allow fractional drain rate

### DIFF
--- a/app/coffee/DrainManager.coffee
+++ b/app/coffee/DrainManager.coffee
@@ -6,9 +6,16 @@ module.exports =
 		clearInterval @interval
 		if rate == 0
 			return
+		else if rate < 1
+			# allow lower drain rates
+			# e.g. rate=0.1 will drain one client every 10 seconds
+			pollingInterval = 1000 / rate
+			rate = 1
+		else
+			pollingInterval = 1000
 		@interval = setInterval () =>
 			@reconnectNClients(io, rate)
-		, 1000
+		, pollingInterval
 
 	RECONNECTED_CLIENTS: {}
 	reconnectNClients: (io, N) ->

--- a/app/coffee/HttpApiController.coffee
+++ b/app/coffee/HttpApiController.coffee
@@ -15,7 +15,7 @@ module.exports = HttpApiController =
 	startDrain: (req, res, next) ->
 		io = req.app.get("io")
 		rate = req.query.rate or "4"
-		rate = parseInt(rate, 10)
+		rate = parseFloat(rate) || 0
 		logger.log {rate}, "setting client drain rate"
 		DrainManager.startDrain io, rate
 		res.send 204


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Allow a slower drain by increasing the polling interval from 1 second to 1/rate seconds when the rate is less than 1 per second.

#### Screenshots

NA

#### Related Issues / PRs

NA

### Review

Small change

#### Potential Impact

Only affects drain

#### Manual Testing Performed

- [X] Tested in local dev env

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?

@henryoswald 