### PR TITLE
Downgraded unathorised log to warning

### DIFF
--- a/app/coffee/WebsocketController.coffee
+++ b/app/coffee/WebsocketController.coffee
@@ -22,7 +22,7 @@ module.exports = WebsocketController =
 
 			if !privilegeLevel or privilegeLevel == ""
 				err = new Error("not authorized")
-				logger.error {err, project_id, user_id, client_id: client.id}, "user is not authorized to join project"
+				logger.warn {err, project_id, user_id, client_id: client.id}, "user is not authorized to join project"
 				return callback(err)
 				
 			client.join project_id

--- a/test/unit/coffee/WebsocketControllerTests.coffee
+++ b/test/unit/coffee/WebsocketControllerTests.coffee
@@ -116,7 +116,10 @@ describe 'WebsocketController', ->
 				@callback
 					.calledWith(new Error("not authorized"))
 					.should.equal true
-	
+
+			it "should not log an error", ->
+				@logger.error.called.should.equal false
+
 	describe "leaveProject", ->
 		beforeEach ->
 			@DocumentUpdaterManager.flushProjectToMongoAndDelete = sinon.stub().callsArg(1)


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Unauthorised access now logs a warning instead of an error.

#### Related Issues / PRs

Fixes https://github.com/overleaf/issues/issues/1791


### Review


#### Potential Impact

None


### Deployment


#### Deployment Checklist

- [ ] Check errors have stopped in production https://sentry.io/overleaf/sl-realtime-prod/issues/396025939/

