### PR TITLE
support multple redis instances for pubsub

### DIFF
--- a/app/coffee/DocumentUpdaterController.coffee
+++ b/app/coffee/DocumentUpdaterController.coffee
@@ -1,7 +1,6 @@
 logger = require "logger-sharelatex"
 settings = require 'settings-sharelatex'
 redis = require("redis-sharelatex")
-rclient = redis.createClient(settings.redis.pubsub)
 SafeJsonParse = require "./SafeJsonParse"
 EventLogger = require "./EventLogger"
 HealthCheckManager = require "./HealthCheckManager"
@@ -12,13 +11,15 @@ MESSAGE_SIZE_LOG_LIMIT = 1024 * 1024 # 1Mb
 module.exports = DocumentUpdaterController =
 	# DocumentUpdaterController is responsible for updates that come via Redis
 	# Pub/Sub from the document updater.
+	rclientList: [redis.createClient(settings.redis.pubsub)]
 
 	listenForUpdatesFromDocumentUpdater: (io) ->
-		rclient.subscribe "applied-ops"
-		rclient.on "message", (channel, message) ->
-			metrics.inc "rclient", 0.001 # global event rate metric
-			EventLogger.debugEvent(channel, message) if settings.debugEvents > 0
-			DocumentUpdaterController._processMessageFromDocumentUpdater(io, channel, message)
+		for rclient in @rclientList
+			rclient.subscribe "applied-ops"
+			rclient.on "message", (channel, message) ->
+				metrics.inc "rclient", 0.001 # global event rate metric
+				EventLogger.debugEvent(channel, message) if settings.debugEvents > 0
+				DocumentUpdaterController._processMessageFromDocumentUpdater(io, channel, message)
 		
 	_processMessageFromDocumentUpdater: (io, channel, message) ->
 		SafeJsonParse.parse message, (error, message) ->

--- a/app/coffee/DocumentUpdaterController.coffee
+++ b/app/coffee/DocumentUpdaterController.coffee
@@ -1,6 +1,6 @@
 logger = require "logger-sharelatex"
 settings = require 'settings-sharelatex'
-redis = require("redis-sharelatex")
+RedisClientManager = require "./RedisClientManager"
 SafeJsonParse = require "./SafeJsonParse"
 EventLogger = require "./EventLogger"
 HealthCheckManager = require "./HealthCheckManager"
@@ -11,7 +11,7 @@ MESSAGE_SIZE_LOG_LIMIT = 1024 * 1024 # 1Mb
 module.exports = DocumentUpdaterController =
 	# DocumentUpdaterController is responsible for updates that come via Redis
 	# Pub/Sub from the document updater.
-	rclientList: [redis.createClient(settings.redis.pubsub)]
+	rclientList: RedisClientManager.createClientList(settings.redis.pubsub, settings.redis.unusedpubsub)
 
 	listenForUpdatesFromDocumentUpdater: (io) ->
 		for rclient in @rclientList

--- a/app/coffee/DocumentUpdaterController.coffee
+++ b/app/coffee/DocumentUpdaterController.coffee
@@ -14,6 +14,7 @@ module.exports = DocumentUpdaterController =
 	rclientList: RedisClientManager.createClientList(settings.redis.pubsub, settings.redis.unusedpubsub)
 
 	listenForUpdatesFromDocumentUpdater: (io) ->
+		logger.log {rclients: @rclientList.length}, "listening for applied-ops events"
 		for rclient, i in @rclientList
 			rclient.subscribe "applied-ops"
 			rclient.on "message", (channel, message) ->

--- a/app/coffee/RedisClientManager.coffee
+++ b/app/coffee/RedisClientManager.coffee
@@ -1,7 +1,18 @@
 redis = require("redis-sharelatex")
+logger = require 'logger-sharelatex'
 
 module.exports = RedisClientManager =
     createClientList: (configs...) ->
         # create a dynamic list of redis clients, excluding any configurations which are not defined
-        clientList = (redis.createClient(x) for x in configs when x?)
+        clientList = for x in configs when x?
+            redisType = if x.cluster?
+                "cluster"
+            else if x.sentinels?
+                "sentinel"
+            else if x.host?
+                "single"
+            else
+                "unknown"
+            logger.log {redis: redisType}, "creating redis client"
+            redis.createClient(x)
         return clientList

--- a/app/coffee/RedisClientManager.coffee
+++ b/app/coffee/RedisClientManager.coffee
@@ -1,7 +1,7 @@
 redis = require("redis-sharelatex")
 
-modules.export = RedisClientManager =
-    createClientList: (configs...)
+module.exports = RedisClientManager =
+    createClientList: (configs...) ->
         # create a dynamic list of redis clients, excluding any configurations which are not defined
-        clientList = (redis.createClient(x) for x in configs when x?))
+        clientList = (redis.createClient(x) for x in configs when x?)
         return clientList

--- a/app/coffee/RedisClientManager.coffee
+++ b/app/coffee/RedisClientManager.coffee
@@ -1,0 +1,7 @@
+redis = require("redis-sharelatex")
+
+modules.export = RedisClientManager =
+    createClientList: (configs...)
+        # create a dynamic list of redis clients, excluding any configurations which are not defined
+        clientList = (redis.createClient(x) for x in configs when x?))
+        return clientList

--- a/app/coffee/WebsocketLoadBalancer.coffee
+++ b/app/coffee/WebsocketLoadBalancer.coffee
@@ -2,14 +2,12 @@ Settings = require 'settings-sharelatex'
 logger = require 'logger-sharelatex'
 redis = require("redis-sharelatex")
 SafeJsonParse = require "./SafeJsonParse"
-rclientPub = redis.createClient(Settings.redis.pubsub)
-rclientSub = redis.createClient(Settings.redis.pubsub)
 EventLogger = require "./EventLogger"
 HealthCheckManager = require "./HealthCheckManager"
 
 module.exports = WebsocketLoadBalancer =
-	rclientPub: rclientPub
-	rclientSub: rclientSub
+	rclientPubList: [redis.createClient(Settings.redis.pubsub)]
+	rclientSubList: [redis.createClient(Settings.redis.pubsub)]
 
 	emitToRoom: (room_id, message, payload...) ->
 		if !room_id?
@@ -20,16 +18,18 @@ module.exports = WebsocketLoadBalancer =
 			message: message
 			payload: payload
 		logger.log {room_id, message, payload, length: data.length}, "emitting to room"
-		@rclientPub.publish "editor-events", data
+		for rclientPub in @rclientPubList
+			rclientPub.publish "editor-events", data
 
 	emitToAll: (message, payload...) ->
 		@emitToRoom "all", message, payload...
 
 	listenForEditorEvents: (io) ->
-		@rclientSub.subscribe "editor-events"
-		@rclientSub.on "message", (channel, message) ->
-			EventLogger.debugEvent(channel, message) if Settings.debugEvents > 0
-			WebsocketLoadBalancer._processEditorEvent io, channel, message
+		for rclientSub in @rclientSubList
+			rclientSub.subscribe "editor-events"
+			rclientSub.on "message", (channel, message) ->
+				EventLogger.debugEvent(channel, message) if Settings.debugEvents > 0
+				WebsocketLoadBalancer._processEditorEvent io, channel, message
 
 	_processEditorEvent: (io, channel, message) ->
 		SafeJsonParse.parse message, (error, message) ->

--- a/app/coffee/WebsocketLoadBalancer.coffee
+++ b/app/coffee/WebsocketLoadBalancer.coffee
@@ -6,7 +6,7 @@ EventLogger = require "./EventLogger"
 HealthCheckManager = require "./HealthCheckManager"
 
 module.exports = WebsocketLoadBalancer =
-	rclientPubList: RedisClientManager.createClientList(Settings.redis.pubsub, Settings.redis.unusedpubsub)
+	rclientPubList: RedisClientManager.createClientList(Settings.redis.pubsub)
 	rclientSubList: RedisClientManager.createClientList(Settings.redis.pubsub, Settings.redis.unusedpubsub)
 
 	emitToRoom: (room_id, message, payload...) ->

--- a/app/coffee/WebsocketLoadBalancer.coffee
+++ b/app/coffee/WebsocketLoadBalancer.coffee
@@ -1,13 +1,13 @@
 Settings = require 'settings-sharelatex'
 logger = require 'logger-sharelatex'
-redis = require("redis-sharelatex")
+RedisClientManager = require "./RedisClientManager"
 SafeJsonParse = require "./SafeJsonParse"
 EventLogger = require "./EventLogger"
 HealthCheckManager = require "./HealthCheckManager"
 
 module.exports = WebsocketLoadBalancer =
-	rclientPubList: [redis.createClient(Settings.redis.pubsub)]
-	rclientSubList: [redis.createClient(Settings.redis.pubsub)]
+	rclientPubList: RedisClientManager.createClientList(Settings.redis.pubsub, Settings.redis.unusedpubsub)
+	rclientSubList: RedisClientManager.createClientList(Settings.redis.pubsub, Settings.redis.unusedpubsub)
 
 	emitToRoom: (room_id, message, payload...) ->
 		if !room_id?

--- a/app/coffee/WebsocketLoadBalancer.coffee
+++ b/app/coffee/WebsocketLoadBalancer.coffee
@@ -25,6 +25,8 @@ module.exports = WebsocketLoadBalancer =
 		@emitToRoom "all", message, payload...
 
 	listenForEditorEvents: (io) ->
+		logger.log {rclients: @rclientPubList.length}, "publishing editor events"
+		logger.log {rclients: @rclientSubList.length}, "listening for editor events"
 		for rclientSub in @rclientSubList
 			rclientSub.subscribe "editor-events"
 			rclientSub.on "message", (channel, message) ->

--- a/test/unit/coffee/WebsocketLoadBalancerTests.coffee
+++ b/test/unit/coffee/WebsocketLoadBalancerTests.coffee
@@ -7,8 +7,8 @@ describe "WebsocketLoadBalancer", ->
 	beforeEach ->
 		@rclient = {}
 		@WebsocketLoadBalancer = SandboxedModule.require modulePath, requires:
-			"redis-sharelatex": 
-				createClient: () => @rclient
+			"./RedisClientManager": 
+				createClientList: () => []
 			"logger-sharelatex": @logger = { log: sinon.stub(), error: sinon.stub() }
 			"./SafeJsonParse": @SafeJsonParse =
 				parse: (data, cb) => cb null, JSON.parse(data)

--- a/test/unit/coffee/WebsocketLoadBalancerTests.coffee
+++ b/test/unit/coffee/WebsocketLoadBalancerTests.coffee
@@ -15,11 +15,12 @@ describe "WebsocketLoadBalancer", ->
 			"./EventLogger": {checkEventOrder: sinon.stub()}
 			"./HealthCheckManager": {check: sinon.stub()}
 		@io = {}
-		@WebsocketLoadBalancer.rclientPub = publish: sinon.stub()
-		@WebsocketLoadBalancer.rclientSub =
+		@WebsocketLoadBalancer.rclientPubList = [{publish: sinon.stub()}]
+		@WebsocketLoadBalancer.rclientSubList = [{
 			subscribe: sinon.stub()
 			on: sinon.stub()
-		
+		}]
+
 		@room_id = "room-id"
 		@message = "message-to-editor"
 		@payload = ["argument one", 42]
@@ -29,7 +30,7 @@ describe "WebsocketLoadBalancer", ->
 			@WebsocketLoadBalancer.emitToRoom(@room_id, @message, @payload...)
 
 		it "should publish the message to redis", ->
-			@WebsocketLoadBalancer.rclientPub.publish
+			@WebsocketLoadBalancer.rclientPubList[0].publish
 				.calledWith("editor-events", JSON.stringify(
 					room_id: @room_id,
 					message: @message
@@ -53,12 +54,12 @@ describe "WebsocketLoadBalancer", ->
 			@WebsocketLoadBalancer.listenForEditorEvents()
 
 		it "should subscribe to the editor-events channel", ->
-			@WebsocketLoadBalancer.rclientSub.subscribe
+			@WebsocketLoadBalancer.rclientSubList[0].subscribe
 				.calledWith("editor-events")
 				.should.equal true
 
 		it "should process the events with _processEditorEvent", ->
-			@WebsocketLoadBalancer.rclientSub.on
+			@WebsocketLoadBalancer.rclientSubList[0].on
 				.calledWith("message", sinon.match.func)
 				.should.equal true
 


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Allow multiple redis configurations for pubsub by replacing the single `rclient`s used for pubsub by a list `rclientList`. 

The `applied-ops` and `editor-events` channels on both redis configurations are subscribed to, the services creating events on those (docupdater and web) can be switched over gracefully.

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/google-ops/issues/333

### Review

Health checks not extended yet TBD
Needs testing locally

#### Potential Impact



#### Manual Testing Performed

- [X] Unit and acceptance tests still work for single redis

#### Accessibility

NA

### Deployment

Deploy this in advance and move everyone over to this version - then other services can be switched when needed. 

#### Deployment Checklist

- [ ] Add settings for second redis configuration
- [ ] Deploy this version
- [ ] Drain old version or wait for everyone to move over to this version
- [ ] Switch one web server to use `editor-events` on second redis
- [ ] If ok, switch all web servers to second redis
- [ ] Switch one docupdater to use `applied-ops` on second redis
- [ ] If ok, switch all docupdaters to second redis
- [ ] Cleanup, remove old client from list so only the new one is in use.

#### Metrics and Monitoring

Docupdater update rate

#### Who Needs to Know?

@henryoswald @mans0954 @jdleesmiller 