### PR TITLE
Ho pubsub healthcheck

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -134,20 +134,18 @@ if Settings.forceDrainMsDelay?
 if Settings.continualPubsubTraffic
 	console.log "continualPubsubTraffic enabled"
 
-	redisClients = [redis.createClient(Settings.redis.documentupdater), redis.createClient(Settings.redis.pubsub)]
+	pubsubClient = redis.createClient(Settings.redis.pubsub)
+	clusterClient = redis.createClient(Settings.redis.websessions)
 
 	publishJob = (channel, callback)->
 		checker = new HealthCheckManager(channel)
 		logger.debug {channel:channel}, "sending pub to keep connection alive"
 		json = JSON.stringify({health_check:true, key: checker.id, date: new Date().toString()})
-		jobs = _.map redisClients, (checkRclient)->
-			return (cb)->
-				checkRclient.publish channel, json, (err)->
-					if err?
-						logger.err {err, channel}, "error publishing pubsub traffic to redis"
-					return cb(err)
+		pubsubClient.publish channel, json, (err)->
+			if err?
+				logger.err {err, channel}, "error publishing pubsub traffic to redis"
+			clusterClient.publish "cluster-continual-traffic", {keep: "alive"}, callback
 
-		async.series jobs, callback
 
 	runPubSubTraffic = ->
 		async.map ["applied-ops", "editor-events"], publishJob, (err)->

--- a/app.coffee
+++ b/app.coffee
@@ -134,15 +134,15 @@ if Settings.forceDrainMsDelay?
 if Settings.continualPubsubTraffic
 	console.log "continualPubsubTraffic enabled"
 
-	redisClients = [redis.createClient(Settings.redis.documentupdater), redis.createClient(Settings.redis.realtime)]
+	redisClients = [redis.createClient(Settings.redis.documentupdater), redis.createClient(Settings.redis.pubsub)]
 
 	publishJob = (channel, callback)->
 		checker = new HealthCheckManager(channel)
 		logger.debug {channel:channel}, "sending pub to keep connection alive"
 		json = JSON.stringify({health_check:true, key: checker.id, date: new Date().toString()})
-		jobs = _.map redisClients, (rclient)->
+		jobs = _.map redisClients, (checkRclient)->
 			return (cb)->
-				rclient.publish channel, json, (err)->
+				checkRclient.publish channel, json, (err)->
 					if err?
 						logger.err {err, channel}, "error publishing pubsub traffic to redis"
 					return cb(err)


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description
we can't send double health check events to same redis, it causes
health check duplicate errors. Commit just sends health check data to
pub sub pair and then sends non health check traffic to cluster to keep
the connection open



#### Screenshots



#### Related Issues / PRs



### Review



#### Potential Impact



#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
