### PR TITLE
remove redis cluster from realtime

### DIFF
--- a/app/coffee/DocumentUpdaterController.coffee
+++ b/app/coffee/DocumentUpdaterController.coffee
@@ -21,9 +21,12 @@ module.exports = DocumentUpdaterController =
 				metrics.inc "rclient", 0.001 # global event rate metric
 				EventLogger.debugEvent(channel, message) if settings.debugEvents > 0
 				DocumentUpdaterController._processMessageFromDocumentUpdater(io, channel, message)
-			do (i) ->
-				rclient.on "message", () ->
-					metrics.inc "rclient-#{i}", 0.001 # per client event rate metric
+		# create metrics for each redis instance only when we have multiple redis clients
+		if @rclientList.length > 1
+			for rclient, i in @rclientList
+				do (i) ->
+					rclient.on "message", () ->
+						metrics.inc "rclient-#{i}", 0.001 # per client event rate metric
 		
 	_processMessageFromDocumentUpdater: (io, channel, message) ->
 		SafeJsonParse.parse message, (error, message) ->

--- a/app/coffee/DocumentUpdaterController.coffee
+++ b/app/coffee/DocumentUpdaterController.coffee
@@ -11,7 +11,7 @@ MESSAGE_SIZE_LOG_LIMIT = 1024 * 1024 # 1Mb
 module.exports = DocumentUpdaterController =
 	# DocumentUpdaterController is responsible for updates that come via Redis
 	# Pub/Sub from the document updater.
-	rclientList: RedisClientManager.createClientList(settings.redis.pubsub, settings.redis.unusedpubsub)
+	rclientList: RedisClientManager.createClientList(settings.redis.pubsub)
 
 	listenForUpdatesFromDocumentUpdater: (io) ->
 		logger.log {rclients: @rclientList.length}, "listening for applied-ops events"

--- a/app/coffee/WebsocketLoadBalancer.coffee
+++ b/app/coffee/WebsocketLoadBalancer.coffee
@@ -7,7 +7,7 @@ HealthCheckManager = require "./HealthCheckManager"
 
 module.exports = WebsocketLoadBalancer =
 	rclientPubList: RedisClientManager.createClientList(Settings.redis.pubsub)
-	rclientSubList: RedisClientManager.createClientList(Settings.redis.pubsub, Settings.redis.unusedpubsub)
+	rclientSubList: RedisClientManager.createClientList(Settings.redis.pubsub)
 
 	emitToRoom: (room_id, message, payload...) ->
 		if !room_id?


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Remove the additional `unused` redis client for cluster, so that only the primary `pubsub` redis sentinel client is used.

Add a check to skip the per-client metrics when there is only one client.

Retaining the infrastructure to support multiple clients in case we need to do any further migrations. 

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/google-ops/issues/333

### Review

Small change.

#### Potential Impact

Low

#### Manual Testing Performed

- [ ] Unit and acceptance tests

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

- [ ]  Check traffic on `SUBSCRIBE applied-ops` and `SUBSCRIBE editor-events` on redis cluster.  There should be none.

#### Metrics and Monitoring

NA

#### Who Needs to Know?
