### PR TITLE
monkeypatch socket.io to fix frame handler in v0.9.16

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -23,6 +23,9 @@ CookieParser = require("cookie-parser")
 DrainManager = require("./app/js/DrainManager")
 HealthCheckManager = require("./app/js/HealthCheckManager")
 
+# work around frame handler bug in socket.io v0.9.16
+require("./socket.io.patch.js") 
+
 # Set up socket.io server
 app = express()
 Metrics.injectMetricsRoute(app)

--- a/socket.io.patch.js
+++ b/socket.io.patch.js
@@ -1,0 +1,43 @@
+var io = require("socket.io");
+
+if (io.version === "0.9.16") {
+  console.log("patching socket.io hybi-16 transport frame prototype");
+  var transports = require("socket.io/lib/transports/websocket/hybi-16.js");
+  transports.prototype.frame = patchedFrameHandler;
+  // file hybi-07-12 has the same problem but no browsers are using that protocol now
+}
+
+function patchedFrameHandler(opcode, str) {
+  var dataBuffer = new Buffer(str),
+    dataLength = dataBuffer.length,
+    startOffset = 2,
+    secondByte = dataLength;
+  if (dataLength === 65536) {
+    console.log("fixing invalid frame length in socket.io");
+  }
+  if (dataLength > 65535) {
+    // original code had > 65536
+    startOffset = 10;
+    secondByte = 127;
+  } else if (dataLength > 125) {
+    startOffset = 4;
+    secondByte = 126;
+  }
+  var outputBuffer = new Buffer(dataLength + startOffset);
+  outputBuffer[0] = opcode;
+  outputBuffer[1] = secondByte;
+  dataBuffer.copy(outputBuffer, startOffset);
+  switch (secondByte) {
+    case 126:
+      outputBuffer[2] = dataLength >>> 8;
+      outputBuffer[3] = dataLength % 256;
+      break;
+    case 127:
+      var l = dataLength;
+      for (var i = 1; i <= 8; ++i) {
+        outputBuffer[startOffset - i] = l & 0xff;
+        l >>>= 8;
+      }
+  }
+  return outputBuffer;
+}


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Workaround for a bug in socket.io v0.9.16 until we can upgrade to socket.io v2.  The bug causes the websocket connection to crash whenever the framesize is exactly 65536, and the editor cannot recover from this. As soon as you come back into the project you usually get the same error.

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2017

### Review

Small change

#### Potential Impact

Low, there is a version check and the code is copied from the original file in socket.io with one change to the condition `>65536` and a console.log.

#### Manual Testing Performed

- [x]  Tested in local dev env
- [x] Unit and acceptance tests

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

- [ ]  Try the test projects in https://github.com/overleaf/issues/issues/1696 and https://github.com/overleaf/issues/issues/1525

#### Metrics and Monitoring

NA

#### Who Needs to Know?
