### PR TITLE
log out of order events now that the rate is lower

### DIFF
--- a/app/coffee/EventLogger.coffee
+++ b/app/coffee/EventLogger.coffee
@@ -35,12 +35,11 @@ module.exports = EventLogger =
 			return # order is ok
 		if (count == previous)
 			metrics.inc "event.#{channel}.duplicate"
-			if Math.random() < 0.01
-				logger.warn {channel:channel, message_id:message_id}, "duplicate event (sampled at 1%)"
+			logger.warn {channel:channel, message_id:message_id}, "duplicate event"
 			return "duplicate"
 		else
 			metrics.inc "event.#{channel}.out-of-order"
-			# logger.warn {channel:channel, message_id:message_id, key:key, previous: previous, count:count}, "out of order event"
+			logger.warn {channel:channel, message_id:message_id, key:key, previous: previous, count:count}, "out of order event"
 			return "out-of-order"
 
 	_storeEventCount: (key, count) ->


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Now that the volume of out-of-order events is lower we can log them for debugging.

#### Related Issues / PRs



### Review

Small change

#### Potential Impact

Low

#### Manual Testing Performed

- [x] Unit and acceptance tests

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

Log for any of these entries in the logs after 24 hours.

#### Who Needs to Know?
