### PR TITLE
Patched EventEmitter for socket.io compatibility with Node >= 7

### DIFF
--- a/socket.io.patch.js
+++ b/socket.io.patch.js
@@ -1,3 +1,9 @@
+// EventEmitter has been removed from process in node >= 7
+// https://github.com/nodejs/node/commit/62b544290a075fe38e233887a06c408ba25a1c71
+if(process.versions.node.split('.')[0] >= 7) {
+  process.EventEmitter = require('events')
+}
+
 var io = require("socket.io");
 
 if (io.version === "0.9.16") {


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

As part of Server Pro revival we need to be able to run all the services under the same node version. This is the only service that fails to bootstrap, and this patch fixes it. I haven't tested the behaviour yet, only the bootstrap.


#### Related Issues / PRs

Contributes to https://github.com/overleaf/issues/issues/2043


### Review



#### Manual Testing Performed

- [x] service bootstraps locally with Node 10
- [x] service continues working under `dev-environment`



### Deployment



#### Deployment Checklist

- [ ] Check service continues working as usual in staging
- [ ] Check service continues working as usual in production
