### PR TITLE
fix async behaviour of join/leave

### DIFF
--- a/app/coffee/RoomManager.coffee
+++ b/app/coffee/RoomManager.coffee
@@ -46,13 +46,15 @@ module.exports = RoomManager =
 
     joinEntity: (client, entity, id, callback) ->
         beforeCount = @_clientsInRoom(client, id)
+        # client joins room immediately but joinDoc request does not complete
+        # until room is subscribed
+        client.join id
         # is this a new room? if so, subscribe
         if beforeCount == 0
             logger.log {entity, id}, "room is now active"
             RoomEvents.once "#{entity}-subscribed-#{id}", (err) ->
                 # only allow the client to join when all the relevant channels have subscribed
-                logger.log {client: client.id, entity, id, beforeCount}, "client joined room after subscribing channel"
-                client.join id
+                logger.log {client: client.id, entity, id, beforeCount}, "client joined new room and subscribed to channel"
                 callback(err)
             RoomEvents.emit "#{entity}-active", id
             IdMap.set(id, entity)


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

This is a fix for the error seen in overleaf/issues#2112.  The `join` to the socket.io room was not executed until after the redis `subscribe` had completed, so that it was possible for a client to leave the room before actually joining it.  

The correct ordering is to join and leave the room synchronously on each request, so that we can use the number of clients in the room as a reference count for whether we need to be subscribed or not.  When a client joins a room we do want wait for the redis subscribe to complete before returning the response to the client.

#### Screenshots

NA

#### Related Issues / PRs

 overleaf/issues#2112 and overleaf/real-time#65

### Review

This is just moving the `join` for the socket.io room up front. I've added an acceptance test that the error is no longer triggered when a `leave` request immediately follows a `join`.  Previously the leave would be actioned before the join had completed, causing the `unexpected unsubscribe` error.


#### Potential Impact

Low

#### Manual Testing Performed

- [X] Unit and acceptance tests


#### Accessibility

NA

### Deployment

The old version was rolled back and is still in dark, so this corrected version can be deployed over it.

#### Deployment Checklist


Follow the checklist in overleaf/real-time#65 to complete the deploy

#### Metrics and Monitoring

As above

#### Who Needs to Know?

@henryoswald 
