### PR TITLE
ignore spurious requests to leave other docs

### DIFF
--- a/test/acceptance/coffee/LeaveDocTests.coffee
+++ b/test/acceptance/coffee/LeaveDocTests.coffee
@@ -16,9 +16,12 @@ describe "leaveDoc", ->
 		@version = 42
 		@ops = ["mock", "doc", "ops"]
 		sinon.spy(logger, "error")
+		sinon.spy(logger, "warn")
+		@other_doc_id = FixturesManager.getRandomId()
 	
 	after ->
 		logger.error.restore() # remove the spy
+		logger.warn.restore()
 			
 	describe "when joined to a doc", ->
 		beforeEach (done) ->
@@ -70,3 +73,12 @@ describe "leaveDoc", ->
 				RealTimeClient.getConnectedClient @client.socket.sessionid, (error, client) =>
 					expect(@doc_id in client.rooms).to.equal false
 					done()
+
+		describe "when sending a leaveDoc for a room the client has not joined ", ->
+			beforeEach (done) ->
+				@client.emit "leaveDoc", @other_doc_id, (error) ->
+					throw error if error?
+					done()
+
+			it "should trigger a warning only", ->
+				sinon.assert.calledWith(logger.warn, sinon.match.any, "ignoring request from client to leave room it is not in")


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Fix to ignore spurious leaveDoc requests (where a client sends a delayed leaveDoc request after a reconnection).

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2112

### Review

Small change, ignore requests to leave a room if the client is not actually present in it.

#### Potential Impact

Low

#### Manual Testing Performed

- [X] Unit and acceptance tests


#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

The "not subscribed - shouldn't happen" error in sentry should be resolved by this.

#### Who Needs to Know?

@henryoswald 