### PR TITLE
status on shutdown

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -56,7 +56,10 @@ app.get "/", (req, res, next) ->
 	res.send "real-time-sharelatex is alive"
 
 app.get "/status", (req, res, next) ->
-	res.send "real-time-sharelatex is alive"
+	if shutDownInProgress
+		res.send 503 # Service unavailable
+	else
+		res.send "real-time-sharelatex is alive"
 
 app.get "/debug/events", (req, res, next) ->
 	Settings.debugEvents = parseInt(req.query?.count,10) || 20

--- a/app.coffee
+++ b/app.coffee
@@ -56,7 +56,7 @@ app.get "/", (req, res, next) ->
 	res.send "real-time-sharelatex is alive"
 
 app.get "/status", (req, res, next) ->
-	if shutDownInProgress
+	if Settings.shutDownInProgress
 		res.send 503 # Service unavailable
 	else
 		res.send "real-time-sharelatex is alive"
@@ -120,17 +120,17 @@ forceDrain = ->
 		DrainManager.startDrain(io, 4)
 	, Settings.forceDrainMsDelay
 
-shutDownInProgress = false
+Settings.shutDownInProgress = false
 if Settings.forceDrainMsDelay?
 	Settings.forceDrainMsDelay = parseInt(Settings.forceDrainMsDelay, 10)
 	logger.log forceDrainMsDelay: Settings.forceDrainMsDelay,"forceDrainMsDelay enabled"
 	for signal in ['SIGINT', 'SIGHUP', 'SIGQUIT', 'SIGUSR1', 'SIGUSR2', 'SIGTERM', 'SIGABRT']
 		process.on signal, ->
-			if shutDownInProgress
+			if Settings.shutDownInProgress
 				logger.log signal: signal, "shutdown already in progress, ignoring signal"
 				return
 			else
-				shutDownInProgress = true
+				Settings.shutDownInProgress = true
 				logger.log signal: signal, "received interrupt, cleaning up"
 				shutdownCleanly(signal)
 				forceDrain()

--- a/app/coffee/DocumentUpdaterManager.coffee
+++ b/app/coffee/DocumentUpdaterManager.coffee
@@ -40,7 +40,8 @@ module.exports = DocumentUpdaterManager =
 		logger.log project_id:project_id, "deleting project from document updater"
 		timer = new metrics.Timer("delete.mongo.project")
 		# flush the project in the background when all users have left
-		url = "#{settings.apis.documentupdater.url}/project/#{project_id}?background=true"
+		url = "#{settings.apis.documentupdater.url}/project/#{project_id}?background=true" +
+			(if settings.shutDownInProgress then "&shutdown=true" else "")
 		request.del url, (err, res, body)->
 			timer.done()
 			if err?

--- a/app/coffee/Router.coffee
+++ b/app/coffee/Router.coffee
@@ -39,6 +39,11 @@ module.exports = Router =
 		app.post "/drain", httpAuth, HttpApiController.startDrain
 
 		session.on 'connection', (error, client, session) ->
+			if settings.shutDownInProgress
+				client.emit("connectionRejected", {message: "retry"})
+				client.disconnect()
+				return
+
 			if client? and error?.message?.match(/could not look up session by key/)
 				logger.warn err: error, client: client?, session: session?, "invalid session"
 				# tell the client to reauthenticate if it has an invalid session key


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Reject new connections when shutdown is in progress.  Sends a 'retry' message back to the client for a quick reconnect.  This is handled by https://github.com/overleaf/web-internal/pull/2077


#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/google-ops/issues/438

### Review

Small change.

#### Potential Impact

Client connections will be rejected, they need to be able to connect elsewhere.  

#### Manual Testing Performed

- [X]  Test in local dev env

#### Accessibility

NA

### Deployment

Needs web change to go out first

#### Deployment Checklist

- [x] Deploy https://github.com/overleaf/web-internal/pull/2077 before this

#### Metrics and Monitoring

NA

#### Who Needs to Know?

NA