### PR TITLE
refresh client list

### DIFF
--- a/app/coffee/WebsocketController.coffee
+++ b/app/coffee/WebsocketController.coffee
@@ -184,7 +184,7 @@ module.exports = WebsocketController =
 			logger.log {user_id, project_id, client_id: client.id}, "getting connected users"
 			AuthorizationManager.assertClientCanViewProject client, (error) ->
 				return callback(error) if error?
-				WebsocketLoadBalancer.emitToRoom project_id, 'clientTracking.refresh', project_id
+				WebsocketLoadBalancer.emitToRoom project_id, 'clientTracking.refresh'
 				setTimeout () ->
 					ConnectedUsersManager.getConnectedUsers project_id, (error, users) ->
 						return callback(error) if error?

--- a/app/coffee/WebsocketController.coffee
+++ b/app/coffee/WebsocketController.coffee
@@ -175,6 +175,7 @@ module.exports = WebsocketController =
 					}, callback)
 				WebsocketLoadBalancer.emitToRoom(project_id, "clientTracking.clientUpdated", cursorData)
 
+	CLIENT_REFRESH_DELAY: 1000
 	getConnectedUsers: (client, callback = (error, users) ->) ->
 		metrics.inc "editor.get-connected-users"
 		Utils.getClientAttributes client, ["project_id", "user_id"], (error, {project_id, user_id}) ->
@@ -183,11 +184,13 @@ module.exports = WebsocketController =
 			logger.log {user_id, project_id, client_id: client.id}, "getting connected users"
 			AuthorizationManager.assertClientCanViewProject client, (error) ->
 				return callback(error) if error?
-				ConnectedUsersManager.getConnectedUsers project_id, (error, users) ->
-					return callback(error) if error?
-					callback null, users
-					logger.log {user_id, project_id, client_id: client.id}, "got connected users"
-					
+				WebsocketLoadBalancer.emitToRoom project_id, 'clientTracking.refresh', project_id
+				setTimeout () ->
+					ConnectedUsersManager.getConnectedUsers project_id, (error, users) ->
+						return callback(error) if error?
+						callback null, users
+						logger.log {user_id, project_id, client_id: client.id}, "got connected users"
+				, WebsocketController.CLIENT_REFRESH_DELAY
 
 	applyOtUpdate: (client, doc_id, update, callback = (error) ->) ->
 		Utils.getClientAttributes client, ["user_id", "project_id"], (error, {user_id, project_id}) ->

--- a/test/unit/coffee/ConnectedUsersManagerTests.coffee
+++ b/test/unit/coffee/ConnectedUsersManagerTests.coffee
@@ -147,18 +147,18 @@ describe "ConnectedUsersManager", ->
 	describe "getConnectedUsers", ->
 
 		beforeEach ->
-			@users = ["1234", "5678", "9123"]
+			@users = ["1234", "5678", "9123", "8234"]
 			@rClient.smembers.callsArgWith(1, null, @users)
 			@ConnectedUsersManager._getConnectedUser = sinon.stub()
-			@ConnectedUsersManager._getConnectedUser.withArgs(@project_id, @users[0]).callsArgWith(2, null, {connected:true, client_id:@users[0]})
-			@ConnectedUsersManager._getConnectedUser.withArgs(@project_id, @users[1]).callsArgWith(2, null, {connected:false, client_id:@users[1]})
-			@ConnectedUsersManager._getConnectedUser.withArgs(@project_id, @users[2]).callsArgWith(2, null, {connected:true, client_id:@users[2]})
+			@ConnectedUsersManager._getConnectedUser.withArgs(@project_id, @users[0]).callsArgWith(2, null, {connected:true, client_age: 2, client_id:@users[0]})
+			@ConnectedUsersManager._getConnectedUser.withArgs(@project_id, @users[1]).callsArgWith(2, null, {connected:false, client_age: 1, client_id:@users[1]})
+			@ConnectedUsersManager._getConnectedUser.withArgs(@project_id, @users[2]).callsArgWith(2, null, {connected:true, client_age: 3, client_id:@users[2]})
+			@ConnectedUsersManager._getConnectedUser.withArgs(@project_id, @users[3]).callsArgWith(2, null, {connected:true, client_age: 11, client_id:@users[3]}) # connected but old
 
-
-		it "should only return the users in the list which are still in redis", (done)->
+		it "should only return the users in the list which are still in redis and recently updated", (done)->
 			@ConnectedUsersManager.getConnectedUsers @project_id, (err, users)=>
 				users.length.should.equal 2
-				users[0].should.deep.equal {client_id:@users[0], connected:true}
-				users[1].should.deep.equal {client_id:@users[2], connected:true}
+				users[0].should.deep.equal {client_id:@users[0], client_age: 2, connected:true}
+				users[1].should.deep.equal {client_id:@users[2], client_age: 3, connected:true}
 				done()
 


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Refresh the client list on demand to reduce the number of stale clients appearing.  We allow one second for the other real-time processes to update the client list following a `clientTracking.refresh` message in the project `editor-events` toom.  We exclude any connectedUser that hasn't been updated in the last 10 seconds from the list of connected users.

#### Screenshots

NA

#### Related Issues / PRs



### Review



#### Potential Impact

Low, affects connected user display only.

#### Manual Testing Performed

- [X] Tested in local dev env

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?
