### PR TITLE
add connected client count metric

### DIFF
--- a/app/coffee/Router.coffee
+++ b/app/coffee/Router.coffee
@@ -78,7 +78,7 @@ module.exports = Router =
 
 			client.on "disconnect", () ->
 				metrics.inc('socket-io.disconnect')
-				metrics.gauge('socket-io.clients', io.sockets.clients()?.length)
+				metrics.gauge('socket-io.clients', io.sockets.clients()?.length - 1)
 				WebsocketController.leaveProject io, client, (err) ->
 					if err?
 						Router._handleError null, err, client, "leaveProject"

--- a/app/coffee/Router.coffee
+++ b/app/coffee/Router.coffee
@@ -56,6 +56,7 @@ module.exports = Router =
 			client.emit("connectionAccepted")
 
 			metrics.inc('socket-io.connection')
+			metrics.gauge('socket-io.clients', io.sockets.clients()?.length)
 
 			logger.log session: session, client_id: client.id, "client connected"
 
@@ -77,6 +78,7 @@ module.exports = Router =
 
 			client.on "disconnect", () ->
 				metrics.inc('socket-io.disconnect')
+				metrics.gauge('socket-io.clients', io.sockets.clients()?.length)
 				WebsocketController.leaveProject io, client, (err) ->
 					if err?
 						Router._handleError null, err, client, "leaveProject"


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Record the number of connected clients for each real-time process

#### Screenshots

NA

#### Related Issues / PRs



### Review

Copied from DrainManager to get the number of connected clients

#### Potential Impact

Low, metric only

#### Manual Testing Performed

- [X] Unit and acceptance tests

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

`socket-io.clients`

#### Who Needs to Know?
