### PR TITLE
clean up unused variable, convert setting to number

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -121,8 +121,8 @@ shutdownCleanly = (signal) ->
 
 Settings.shutDownInProgress = false
 if Settings.shutdownDrainTimeWindow?
-	Settings.forceDrainMsDelay = parseInt(Settings.shutdownDrainTimeWindow, 10)
-	logger.log shutdownDrainTimeWindow: Settings.shutdownDrainTimeWindow,"shutdownDrainTimeWindow enabled"
+	shutdownDrainTimeWindow = parseInt(Settings.shutdownDrainTimeWindow, 10)
+	logger.log shutdownDrainTimeWindow: shutdownDrainTimeWindow,"shutdownDrainTimeWindow enabled"
 	for signal in ['SIGINT', 'SIGHUP', 'SIGQUIT', 'SIGUSR1', 'SIGUSR2', 'SIGTERM', 'SIGABRT']
 		process.on signal, ->
 			if Settings.shutDownInProgress
@@ -130,8 +130,8 @@ if Settings.shutdownDrainTimeWindow?
 				return
 			else
 				Settings.shutDownInProgress = true
-				logger.log signal: signal, "received interrupt, starting drain over #{Settings.shutdownDrainTimeWindow} mins"
-				DrainManager.startDrainTimeWindow(io, Settings.shutdownDrainTimeWindow)
+				logger.log signal: signal, "received interrupt, starting drain over #{shutdownDrainTimeWindow} mins"
+				DrainManager.startDrainTimeWindow(io, shutdownDrainTimeWindow)
 				shutdownCleanly(signal)
 
 


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Clean up stray unused variable, `forceDrainMsDelay`, convert the setting to a number and use that for `shutdownDrainTimeWindow`.

#### Screenshots



#### Related Issues / PRs



### Review



#### Potential Impact



#### Manual Testing Performed

- [ ]
- [ ]

#### Accessibility



### Deployment



#### Deployment Checklist

- [ ] Update documentation not included in the PR (if any)
- [ ]

#### Metrics and Monitoring



#### Who Needs to Know?
