### PR TITLE
use a separate field to improve the connected client logic

### DIFF
--- a/test/unit/coffee/ConnectedUsersManagerTests.coffee
+++ b/test/unit/coffee/ConnectedUsersManagerTests.coffee
@@ -124,9 +124,8 @@ describe "ConnectedUsersManager", ->
 
 		it "should return a connected user if there is a user object", (done)->
 			cursorData = JSON.stringify(cursorData:{row:1})
-			@rClient.hgetall.callsArgWith(1, null, {connected_at:new Date(), cursorData})
+			@rClient.hgetall.callsArgWith(1, null, {connected_at:new Date(), user_id: @user_id, cursorData, last_updated_at: "#{Date.now()}"})
 			@ConnectedUsersManager._getConnectedUser @project_id, @client_id, (err, result)=>
-				result.connected.should.equal true
 				result.client_id.should.equal @client_id
 				done()
 
@@ -144,21 +143,27 @@ describe "ConnectedUsersManager", ->
 				result.client_id.should.equal @client_id
 				done()
 
+		it "should return a not connected user if there is no user_id and only a socket_checked_at field", (done)->
+			@rClient.hgetall.callsArgWith(1, null, {connected_at:new Date(), socket_checked_at: "#{Date.now()}"})
+			@ConnectedUsersManager._getConnectedUser @project_id, @client_id, (err, result)=>
+				result.connected.should.equal false
+				result.client_id.should.equal @client_id
+				done()
+
 	describe "getConnectedUsers", ->
 
 		beforeEach ->
-			@users = ["1234", "5678", "9123", "8234"]
+			@users = ["1234", "5678", "9123"]
 			@rClient.smembers.callsArgWith(1, null, @users)
 			@ConnectedUsersManager._getConnectedUser = sinon.stub()
-			@ConnectedUsersManager._getConnectedUser.withArgs(@project_id, @users[0]).callsArgWith(2, null, {connected:true, client_age: 2, client_id:@users[0]})
-			@ConnectedUsersManager._getConnectedUser.withArgs(@project_id, @users[1]).callsArgWith(2, null, {connected:false, client_age: 1, client_id:@users[1]})
-			@ConnectedUsersManager._getConnectedUser.withArgs(@project_id, @users[2]).callsArgWith(2, null, {connected:true, client_age: 3, client_id:@users[2]})
-			@ConnectedUsersManager._getConnectedUser.withArgs(@project_id, @users[3]).callsArgWith(2, null, {connected:true, client_age: 11, client_id:@users[3]}) # connected but old
+			@ConnectedUsersManager._getConnectedUser.withArgs(@project_id, @users[0]).callsArgWith(2, null, {connected:true, client_id:@users[0]})
+			@ConnectedUsersManager._getConnectedUser.withArgs(@project_id, @users[1]).callsArgWith(2, null, {connected:false, client_id:@users[1]})
+			@ConnectedUsersManager._getConnectedUser.withArgs(@project_id, @users[2]).callsArgWith(2, null, {connected:true, client_id:@users[2]})
 
-		it "should only return the users in the list which are still in redis and recently updated", (done)->
+		it "should only return the users in the list which are still in redis", (done)->
 			@ConnectedUsersManager.getConnectedUsers @project_id, (err, users)=>
 				users.length.should.equal 2
-				users[0].should.deep.equal {client_id:@users[0], client_age: 2, connected:true}
-				users[1].should.deep.equal {client_id:@users[2], client_age: 3, connected:true}
+				users[0].should.deep.equal {client_id:@users[0], connected:true}
+				users[1].should.deep.equal {client_id:@users[2], connected:true}
 				done()
 

--- a/test/unit/coffee/WebsocketLoadBalancerTests.coffee
+++ b/test/unit/coffee/WebsocketLoadBalancerTests.coffee
@@ -17,6 +17,7 @@ describe "WebsocketLoadBalancer", ->
 			"./HealthCheckManager": {check: sinon.stub()}
 			"./RoomManager" : @RoomManager = {eventSource: sinon.stub().returns @RoomEvents}
 			"./ChannelManager": @ChannelManager = {publish: sinon.stub()}
+			"./ConnectedUsersManager": @ConnectedUsersManager = {refreshClient: sinon.stub()}
 		@io = {}
 		@WebsocketLoadBalancer.rclientPubList = [{publish: sinon.stub()}]
 		@WebsocketLoadBalancer.rclientSubList = [{


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Fix logic for clients that have expired from redis.  If the client record expired, the `last_updated_at` field would be added back on its own when we ping the clients.  This made it look like the user was connected, but their record was empty.  

The fix for this is to check that the user_id field is present so that undefined users never show up in the list. 

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2179

### Review

The additional check for `!result.user_id` fixes the problem.

I've also moved the connection tracking timestamp to a separate `last_response_at` field (the last time we successfully checked the client was connected) to avoid confusion with the `last_updated_at` field (the last time the user moved the cursor).

#### Potential Impact

Low

#### Manual Testing Performed

- [ ] Unit and acceptance tests

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?
