### PR TITLE
only show connected users with a user_id

### DIFF
--- a/app/coffee/ConnectedUsersManager.coffee
+++ b/app/coffee/ConnectedUsersManager.coffee
@@ -60,7 +60,7 @@ module.exports =
 
 	_getConnectedUser: (project_id, client_id, callback)->
 		rclient.hgetall Keys.connectedUser({project_id, client_id}), (err, result)->
-			if !result? or Object.keys(result).length == 0
+			if !result? or Object.keys(result).length == 0 or !result.user_id
 				result =
 					connected : false
 					client_id:client_id

--- a/test/unit/coffee/ConnectedUsersManagerTests.coffee
+++ b/test/unit/coffee/ConnectedUsersManagerTests.coffee
@@ -124,7 +124,7 @@ describe "ConnectedUsersManager", ->
 
 		it "should return a connected user if there is a user object", (done)->
 			cursorData = JSON.stringify(cursorData:{row:1})
-			@rClient.hgetall.callsArgWith(1, null, {connected_at:new Date(), cursorData})
+			@rClient.hgetall.callsArgWith(1, null, {connected_at:new Date(), user_id: @user._id, last_updated_at: "#{Date.now()}", cursorData})
 			@ConnectedUsersManager._getConnectedUser @project_id, @client_id, (err, result)=>
 				result.connected.should.equal true
 				result.client_id.should.equal @client_id

--- a/test/unit/coffee/WebsocketLoadBalancerTests.coffee
+++ b/test/unit/coffee/WebsocketLoadBalancerTests.coffee
@@ -17,6 +17,7 @@ describe "WebsocketLoadBalancer", ->
 			"./HealthCheckManager": {check: sinon.stub()}
 			"./RoomManager" : @RoomManager = {eventSource: sinon.stub().returns @RoomEvents}
 			"./ChannelManager": @ChannelManager = {publish: sinon.stub()}
+			"./ConnectedUsersManager": @ConnectedUsersManager = {refreshClient: sinon.stub()}
 		@io = {}
 		@WebsocketLoadBalancer.rclientPubList = [{publish: sinon.stub()}]
 		@WebsocketLoadBalancer.rclientSubList = [{


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Minimal fix for https://github.com/overleaf/issues/issues/2179,  only return users with a user_id.

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2179

Longer cleanup PR at https://github.com/overleaf/real-time/pull/76, I won't deploy that today.

### Review

Smallest change to fix this.

#### Potential Impact

Low

#### Manual Testing Performed

- [X] Unit and acceptance tests 

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?
