### PR TITLE
Generate retryable error when hitting rate limits in web

### DIFF
--- a/app/coffee/Errors.coffee
+++ b/app/coffee/Errors.coffee
@@ -1,0 +1,10 @@
+CodedError = (message, code) ->
+	error = new Error(message)
+	error.name = "CodedError"
+	error.code = code
+	error.__proto__ = CodedError.prototype
+	return error
+CodedError.prototype.__proto__ = Error.prototype
+
+module.exports = Errors =
+	CodedError: CodedError

--- a/app/coffee/Router.coffee
+++ b/app/coffee/Router.coffee
@@ -21,6 +21,9 @@ module.exports = Router =
 				attrs[key] = value
 			attrs.client_id = client.id
 			attrs.err = error
+			if error.name == "CodedError"
+				logger.warn attrs, error.message, code: error.code
+				return callback {message: error.message, code: error.code}
 			if error.message in ["not authorized", "doc updater could not load requested ops", "no project_id found on client"]
 				logger.warn attrs, error.message
 				return callback {message: error.message}

--- a/test/acceptance/coffee/JoinProjectTests.coffee
+++ b/test/acceptance/coffee/JoinProjectTests.coffee
@@ -89,3 +89,20 @@ describe "joinProject", ->
 			RealTimeClient.getConnectedClient @client.socket.sessionid, (error, client) =>
 				expect(@project_id in client.rooms).to.equal false
 				done()
+
+	describe "when over rate limit", ->
+		before (done) ->
+			async.series [
+				(cb) =>
+					@client = RealTimeClient.connect()
+					@client.on "connectionAccepted", cb
+
+				(cb) =>
+					@client.emit "joinProject", project_id: 'rate-limited', (@error) =>
+						cb()
+			], done
+
+		it "should return a TooManyRequests error code", ->
+			@error.message.should.equal "rate-limit hit when joining project"
+			@error.code.should.equal "TooManyRequests"
+

--- a/test/acceptance/coffee/helpers/MockWebServer.coffee
+++ b/test/acceptance/coffee/helpers/MockWebServer.coffee
@@ -19,12 +19,15 @@ module.exports = MockWebServer =
 	joinProjectRequest: (req, res, next) ->
 		{project_id} = req.params
 		{user_id} = req.query
-		MockWebServer.joinProject project_id, user_id, (error, project, privilegeLevel) ->
-			return next(error) if error?
-			res.json {
-				project: project
-				privilegeLevel: privilegeLevel
-			}
+		if project_id == 'rate-limited'
+			res.status(429).send()
+		else
+			MockWebServer.joinProject project_id, user_id, (error, project, privilegeLevel) ->
+				return next(error) if error?
+				res.json {
+					project: project
+					privilegeLevel: privilegeLevel
+				}
 	
 	running: false
 	run: (callback = (error) ->) ->

--- a/test/unit/coffee/WebApiManagerTests.coffee
+++ b/test/unit/coffee/WebApiManagerTests.coffee
@@ -3,6 +3,7 @@ should = chai.should()
 sinon = require("sinon")
 modulePath = "../../../app/js/WebApiManager.js"
 SandboxedModule = require('sandboxed-module')
+{ CodedError } = require('../../../app/js/Errors')
 
 describe 'WebApiManager', ->
 	beforeEach ->
@@ -61,3 +62,12 @@ describe 'WebApiManager', ->
 					.calledWith(new Error("non-success code from web: 500"))
 					.should.equal true
 	
+		describe "when the project is over its rate limit", ->
+			beforeEach ->
+				@request.post = sinon.stub().callsArgWith(1, null, {statusCode: 429}, null)
+				@WebApiManager.joinProject @project_id, @user_id, @callback
+
+			it "should call the callback with a TooManyRequests error code", ->
+				@callback
+					.calledWith(new CodedError("rate-limit hit when joining project", "TooManyRequests"))
+					.should.equal true


### PR DESCRIPTION
### Description

As part of the testing for overleaf/issues#2176, we discovered that it's easy to hit the project-join rate limit when reconnecting lots of times. When that happens, the connection fails pretty hard and you see a big scary warning.

This patch flags 429 as a retryable error, so that we can add logic to the client to handle this more gracefully.

#### Related Issues / PRs

overleaf/issues#2176

### Review

Added an `Errors` mechanism so that we can (in the future) generate multiple types of retryable error.

#### Who Needs to Know?

cc @timothee-alby, @henryoswald 