### PR TITLE
[RoomManager] drop duplicate joining of entities

### DIFF
--- a/app/coffee/RoomManager.coffee
+++ b/app/coffee/RoomManager.coffee
@@ -64,7 +64,6 @@ module.exports = RoomManager =
             metrics.gauge "room-listeners", RoomEvents.eventNames().length
         else
             logger.log {client: client.id, entity, id, beforeCount}, "client joined existing room"
-            client.join id
             callback()
 
     leaveEntity: (client, entity, id) ->


### PR DESCRIPTION
### Description
https://github.com/overleaf/real-time/pull/67 moved the client join out of the branch for empty rooms. Unfortunately the join in the branch for already present clients was not removed.

With socket.io v2 this seems to contribute to an unstable acceptance test that challenges a race condition of the join/leave logic.
https://github.com/overleaf/real-time/blob/2060a2fdc5c6badfa92a717a6ff35dfe91ad9f20/test/acceptance/coffee/LeaveDocTests.coffee#L63-L65

#### Screenshots



#### Related Issues / PRs
https://github.com/overleaf/real-time/pull/67
https://github.com/overleaf/issues/issues/2757


### Review



#### Potential Impact



#### Manual Testing Performed


#### Accessibility



### Deployment



#### Deployment Checklist

#### Metrics and Monitoring

#### Who Needs to Know?
@briangough 