### PR TITLE
[LeaveDocTests] fix a test that is not stable with socket.io v2

### DIFF
--- a/test/acceptance/coffee/LeaveDocTests.coffee
+++ b/test/acceptance/coffee/LeaveDocTests.coffee
@@ -61,9 +61,11 @@ describe "leaveDoc", ->
 			describe "when sending a leaveDoc request before the previous joinDoc request has completed", ->
 				beforeEach (done) ->
 					@client.emit "joinDoc", @doc_id, () ->
-					@client.emit "leaveDoc", @doc_id, (error) ->
-						throw error if error?
-						done()
+					setTimeout () =>
+						@client.emit "leaveDoc", @doc_id, (error) ->
+							throw error if error?
+							done()
+					, 1
 
 				it "should not trigger an error", ->
 					sinon.assert.neverCalledWith(logger.error, sinon.match.any, "not subscribed - shouldn't happen")

--- a/test/acceptance/coffee/LeaveDocTests.coffee
+++ b/test/acceptance/coffee/LeaveDocTests.coffee
@@ -58,21 +58,20 @@ describe "leaveDoc", ->
 					expect(@doc_id in client.rooms).to.equal false
 					done()
 
-		describe "when sending a leaveDoc request before the previous joinDoc request has completed", ->
-			beforeEach (done) ->
-				@client.emit "leaveDoc", @doc_id, () ->
-				@client.emit "joinDoc", @doc_id, () ->
-				@client.emit "leaveDoc", @doc_id, (error) ->
-					throw error if error?
-					done()
+			describe "when sending a leaveDoc request before the previous joinDoc request has completed", ->
+				beforeEach (done) ->
+					@client.emit "joinDoc", @doc_id, () ->
+					@client.emit "leaveDoc", @doc_id, (error) ->
+						throw error if error?
+						done()
 
-			it "should not trigger an error", ->
-				sinon.assert.neverCalledWith(logger.error, sinon.match.any, "not subscribed - shouldn't happen")
+				it "should not trigger an error", ->
+					sinon.assert.neverCalledWith(logger.error, sinon.match.any, "not subscribed - shouldn't happen")
 
-			it "should have left the doc room", (done) ->
-				RealTimeClient.getConnectedClient @client.socket.sessionid, (error, client) =>
-					expect(@doc_id in client.rooms).to.equal false
-					done()
+				it "should have left the doc room", (done) ->
+					RealTimeClient.getConnectedClient @client.socket.sessionid, (error, client) =>
+						expect(@doc_id in client.rooms).to.equal false
+						done()
 
 		describe "when sending a leaveDoc for a room the client has not joined ", ->
 			beforeEach (done) ->


### PR DESCRIPTION
### Description

The socket.io client.join/client.leave logic would:
 - in v2: emit the join/leave event first, before updating the internal client state.
 - in v0: update the internal state, then fire the event

Upon a leave request the RoomManager would check the internal state of the client for an existing membership in a given room. In case of no membership, the request would perform no operation.

This does not play nice with the test that joins and leaves at almost the same time.

In v0 the race condition is unlikely to appear:

| time | join              | leave            |
| ---- | ----------------- | ---------------- |
| 0    | req start         |                  |
| 1    | update membership | req start        |
| 2    | fire join         | check membership |
| 3    |                   | fire leave       |

In v2 however the race condition is very likely to occur:

| time | join              | leave            |
| ---- | ----------------- | ---------------- |
| 0    | req start         |                  |
| 1    | fire join         | req start        |
| 2    | update membership | check membership |


#### Screenshots



#### Related Issues / PRs
#79 
https://github.com/overleaf/issues/issues/2757


### Review



#### Potential Impact



#### Manual Testing Performed

- 100 consecutive test runs all passed

  ```bash
  $ rm -f node_modules/out \
  && for i in `seq 100`; do \
    npx mocha --exit app.js test/acceptance/js/LeaveDocTests.js &>/dev/null; \
    echo $? >> node_modules/out; \
  done \
  && sort node_modules/out | uniq -c

  #    100 0
  ```

#### Accessibility



### Deployment



#### Deployment Checklist


#### Metrics and Monitoring



#### Who Needs to Know?
