### PR TITLE
Filter "comments" if restricted user.

### DIFF
--- a/app/coffee/WebsocketController.coffee
+++ b/app/coffee/WebsocketController.coffee
@@ -85,7 +85,7 @@ module.exports = WebsocketController =
 
 	joinDoc: (client, doc_id, fromVersion = -1, options, callback = (error, doclines, version, ops, ranges) ->) ->
 		metrics.inc "editor.join-doc"
-		Utils.getClientAttributes client, ["project_id", "user_id"], (error, {project_id, user_id}) ->
+		Utils.getClientAttributes client, ["project_id", "user_id", "is_restricted_user"], (error, {project_id, user_id, is_restricted_user}) ->
 			return callback(error) if error?
 			return callback(new Error("no project_id found on client")) if !project_id?
 			logger.log {user_id, project_id, doc_id, fromVersion, client_id: client.id}, "client joining doc"
@@ -98,6 +98,9 @@ module.exports = WebsocketController =
 					return callback(error) if error?
 					DocumentUpdaterManager.getDocument project_id, doc_id, fromVersion, (error, lines, version, ranges, ops) ->
 						return callback(error) if error?
+
+						if is_restricted_user and ranges?.comments?
+							ranges.comments = []
 
 						# Encode any binary bits of data so it can go via WebSockets
 						# See http://ecmanaut.blogspot.co.uk/2006/07/encoding-decoding-utf8-in-javascript.html

--- a/test/unit/coffee/WebsocketControllerTests.coffee
+++ b/test/unit/coffee/WebsocketControllerTests.coffee
@@ -238,6 +238,7 @@ describe 'WebsocketController', ->
 			@options = {}
 
 			@client.params.project_id = @project_id
+			@client.params.is_restricted_user = false
 			@AuthorizationManager.addAccessToDoc = sinon.stub()
 			@AuthorizationManager.assertClientCanViewProject = sinon.stub().callsArgWith(1, null)
 			@DocumentUpdaterManager.getDocument = sinon.stub().callsArgWith(3, null, @doc_lines, @version, @ranges, @ops)
@@ -337,6 +338,16 @@ describe 'WebsocketController', ->
 
 			it "should not call the DocumentUpdaterManager", ->
 				@DocumentUpdaterManager.getDocument.called.should.equal false
+
+		describe "with a restricted client", ->
+			beforeEach ->
+				@ranges.comments = [{op: {a: 1}}, {op: {a: 2}}]
+				@client.params.is_restricted_user = true
+				@WebsocketController.joinDoc @client, @doc_id, -1, @options, @callback
+
+			it "should overwrite ranges.comments with an empty list", ->
+				ranges = @callback.args[0][4]
+				expect(ranges.comments).to.deep.equal []
 
 	describe "leaveDoc", ->
 		beforeEach ->


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description

Resurrection of https://github.com/overleaf/real-time/pull/81, and following on from its reversion in https://github.com/overleaf/real-time/pull/85.

Track the `isRestrictedUser` flag on clients  then, don't send new chat messages and new comments to those restricted clients.
We do this because we don't want to leak private information (email addresses
and names) to "restricted" users, those who have read-only access via a
shared token.

#### New changes since last PR

- Hide review comments from restricted users when they join a document


#### Related Issues / PRs

- Part of https://github.com/overleaf/issues/issues/2319
- Sibling of https://github.com/overleaf/web-internal/pull/2306 (current)
- Sibling of https://github.com/overleaf/web-internal/pull/2206 (old)


### Review


#### Potential Impact

It's real-time, so pretty high. We're now using Async in the broadcast-to-clients loop, which could have a performance impact.


#### Manual Testing Performed

- [x] Test that the editor works
- [x] Check that chat and comment messages are not sent to restricted clients
- [x] Check that chat and comment messages _are_ sent to other non-restricted clients
- [X] Check that comments are not received on the `joinDoc` event

### Deployment

- Depends on https://github.com/overleaf/web-internal/pull/2206 to have any effect.


#### Deployment Checklist

- [ ] Keep an eye on metrics for real-time


#### Metrics and Monitoring

- Keep an eye on cpu and memory in real-time


#### Who Needs to Know?
@jdleesmiller 
