### PR TITLE
avoid emitting when client not connected

### DIFF
--- a/app/coffee/WebsocketLoadBalancer.coffee
+++ b/app/coffee/WebsocketLoadBalancer.coffee
@@ -96,6 +96,9 @@ module.exports = WebsocketLoadBalancer =
 					, (client, cb) ->
 						Utils.getClientAttributes client, ['is_restricted_user'], (err, {is_restricted_user}) ->
 							return cb(err) if err?
+							if !client.connected
+								logger.warn {channel:channel, client: client.id}, "skipping emit, client not connected"
+								return cb()
 							if !seen[client.id]
 								seen[client.id] = true
 								if !(is_restricted_user && message.message not in RESTRICTED_USER_MESSAGE_TYPE_PASS_LIST)

--- a/app/coffee/WebsocketLoadBalancer.coffee
+++ b/app/coffee/WebsocketLoadBalancer.coffee
@@ -96,7 +96,7 @@ module.exports = WebsocketLoadBalancer =
 					, (client, cb) ->
 						Utils.getClientAttributes client, ['is_restricted_user'], (err, {is_restricted_user}) ->
 							return cb(err) if err?
-							if !client.connected
+							if client.disconnected
 								logger.warn {channel:channel, client: client.id}, "skipping emit, client not connected"
 								return cb()
 							if !seen[client.id]


### PR DESCRIPTION
the emit is happening asynchronously after the client list is computed,
so clients may have disconnected in the intervening time.
