### PR TITLE
Don't shut down on uncaught EPIPE

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -141,6 +141,8 @@ if Settings.shutdownDrainTimeWindow?
 	if Settings.errors?.catchUncaughtErrors
 		process.removeAllListeners('uncaughtException')
 		process.on 'uncaughtException', (error) ->
+			if error.code == 'EPIPE'
+				return logger.warn err: error, 'attempted to write to disconnected client'
 			logger.error err: error, 'uncaught exception'
 			if Settings.errors?.shutdownOnUncaughtError
 				drainAndShutdown('SIGABRT')


### PR DESCRIPTION
### Description

`EPIPE` when writing to the client sholdn't be considered a fatal error - it's just us trying to talk to a dead client.

Patch to log a warning instead of shut down, when this occurs.

#### Related Issues / PRs

See overleaf/issues#1833
