### PR TITLE
Handle ECONNRESET in the same way as EPIPE

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -142,7 +142,7 @@ if Settings.shutdownDrainTimeWindow?
 		process.removeAllListeners('uncaughtException')
 		process.on 'uncaughtException', (error) ->
 			if ['EPIPE', 'ECONNRESET'].includes(error.code)
-				Metrics.inc('disconnected_write')
+				Metrics.inc('disconnected_write', 1, {status: error.code})
 				return logger.warn err: error, 'attempted to write to disconnected client'
 			logger.error err: error, 'uncaught exception'
 			if Settings.errors?.shutdownOnUncaughtError

--- a/app.coffee
+++ b/app.coffee
@@ -141,7 +141,8 @@ if Settings.shutdownDrainTimeWindow?
 	if Settings.errors?.catchUncaughtErrors
 		process.removeAllListeners('uncaughtException')
 		process.on 'uncaughtException', (error) ->
-			if error.code == 'EPIPE'
+			if ['EPIPE', 'ECONNRESET'].includes(error.code)
+				Metrics.inc('disconnected_write')
 				return logger.warn err: error, 'attempted to write to disconnected client'
 			logger.error err: error, 'uncaught exception'
 			if Settings.errors?.shutdownOnUncaughtError


### PR DESCRIPTION
### Description

We've seen `ECONNRESET` coming up the same way as `EPIPE` which should also not be fatal.

One thing to consider: If the clients don't get cleaned up at this point we might see some heavy leakage. Added a metric to track this.

#### Related Issues / PRs

See overleaf/issues#1833