### PR TITLE
[misc] test/acceptance: SessionTests: wait for the client to connect

### DIFF
--- a/test/acceptance/coffee/SessionTests.coffee
+++ b/test/acceptance/coffee/SessionTests.coffee
@@ -12,15 +12,18 @@ describe "Session", ->
 			}, (error) =>
 				throw error if error?
 				@client = RealTimeClient.connect()
-				return done()
+
+				@disconnected = false
+				@client.on "disconnect", () =>
+					@disconnected = true
+
+				@client.on "connect", () ->
+					done()
 			return null
 
 		it "should not get disconnected", (done) ->
-			disconnected = false
-			@client.on "disconnect", () ->
-				disconnected = true
 			setTimeout () =>
-				expect(disconnected).to.equal false
+				expect(@disconnected).to.equal false
 				done()
 			, 500
 			


### PR DESCRIPTION
### Description
The SessionTests depend on a connected client that might then get disconnected in case the session is missing (which is not the case). The test setup should wait for the client to connect.

#### Related Issues / PRs
https://github.com/overleaf/issues/issues/2757


#### Potential Impact
Affects tests only.
