### PR TITLE
[misc] test/acceptance: use the correct redis instances

### DIFF
--- a/test/acceptance/coffee/ApplyUpdateTests.coffee
+++ b/test/acceptance/coffee/ApplyUpdateTests.coffee
@@ -8,7 +8,7 @@ FixturesManager = require "./helpers/FixturesManager"
 
 settings = require "settings-sharelatex"
 redis = require "redis-sharelatex"
-rclient = redis.createClient(settings.redis.websessions)
+rclient = redis.createClient(settings.redis.documentupdater)
 
 redisSettings = settings.redis
 

--- a/test/acceptance/coffee/ReceiveUpdateTests.coffee
+++ b/test/acceptance/coffee/ReceiveUpdateTests.coffee
@@ -10,7 +10,7 @@ async = require "async"
 
 settings = require "settings-sharelatex"
 redis = require "redis-sharelatex"
-rclient = redis.createClient(settings.redis.websessions)
+rclient = redis.createClient(settings.redis.pubsub)
 
 describe "receiveUpdate", ->
 	before (done) ->


### PR DESCRIPTION
### Description
Some of the redis settings are misaligned in the tests. This is not that much of an issue as we run just one redis instance for the acceptance tests.

#### Related Issues / PRs
https://github.com/overleaf/issues/issues/2757

#### Potential Impact
Affects tests only.
