### PR TITLE
[misc] test/acceptance: ReceiveUpdateTests: add 2nd project/3rd client

### DIFF
--- a/test/acceptance/coffee/ReceiveUpdateTests.coffee
+++ b/test/acceptance/coffee/ReceiveUpdateTests.coffee
@@ -13,7 +13,7 @@ redis = require "redis-sharelatex"
 rclient = redis.createClient(settings.redis.pubsub)
 
 describe "receiveUpdate", ->
-	before (done) ->
+	beforeEach (done) ->
 		@lines = ["test", "doc", "lines"]
 		@version = 42
 		@ops = ["mock", "doc", "ops"]
@@ -52,15 +52,52 @@ describe "receiveUpdate", ->
 			
 			(cb) =>
 				@clientB.emit "joinDoc", @doc_id, cb
+
+			(cb) =>
+				FixturesManager.setUpProject {
+					privilegeLevel: "owner"
+					project: {name: "Test Project"}
+				}, (error, {user_id: @user_id_second, project_id: @project_id_second}) => cb()
+
+			(cb) =>
+				FixturesManager.setUpDoc @project_id_second, {@lines, @version, @ops}, (e, {doc_id: @doc_id_second}) =>
+					cb(e)
+
+			(cb) =>
+				@clientC = RealTimeClient.connect()
+				@clientC.on "connectionAccepted", cb
+
+			(cb) =>
+				@clientC.emit "joinProject", {
+					project_id: @project_id_second
+				}, cb
+			(cb) =>
+				@clientC.emit "joinDoc", @doc_id_second, cb
+
+			(cb) =>
+				@clientAUpdates = []
+				@clientA.on "otUpdateApplied", (update) => @clientAUpdates.push(update)
+				@clientBUpdates = []
+				@clientB.on "otUpdateApplied", (update) => @clientBUpdates.push(update)
+				@clientCUpdates = []
+				@clientC.on "otUpdateApplied", (update) => @clientCUpdates.push(update)
+
+				@clientAErrors = []
+				@clientA.on "otUpdateError", (error) => @clientAErrors.push(error)
+				@clientBErrors = []
+				@clientB.on "otUpdateError", (error) => @clientBErrors.push(error)
+				@clientCErrors = []
+				@clientC.on "otUpdateError", (error) => @clientCErrors.push(error)
+				cb()
 		], done
-		
+
+	afterEach () ->
+		@clientA?.disconnect()
+		@clientB?.disconnect()
+		@clientC?.disconnect()
+
 	describe "with an update from clientA", ->
-		before (done) ->
-			@clientAUpdates = []
-			@clientA.on "otUpdateApplied", (update) => @clientAUpdates.push(update)
-			@clientBUpdates = []
-			@clientB.on "otUpdateApplied", (update) => @clientBUpdates.push(update)
-			
+		beforeEach (done) ->
 			@update = {
 				doc_id: @doc_id
 				op:
@@ -80,21 +117,69 @@ describe "receiveUpdate", ->
 			@clientAUpdates.should.deep.equal [{
 				v: @version, doc: @doc_id
 			}]
-			
-	describe "with an error", ->
-		before (done) ->
-			@clientAErrors = []
-			@clientA.on "otUpdateError", (error) => @clientAErrors.push(error)
-			@clientBErrors = []
-			@clientB.on "otUpdateError", (error) => @clientBErrors.push(error)
-			
+
+		it "should send nothing to clientC", ->
+			@clientCUpdates.should.deep.equal []
+
+	describe "with an update from clientC", ->
+		beforeEach (done) ->
+			@update = {
+				doc_id: @doc_id_second
+				op:
+					meta:
+						source: @clientC.socket.sessionid
+					v: @version
+					doc: @doc_id_second
+					op: [{i: "update from clientC", p: 50}]
+			}
+			rclient.publish "applied-ops", JSON.stringify(@update)
+			setTimeout done, 200 # Give clients time to get message
+
+		it "should send nothing to clientA", ->
+			@clientAUpdates.should.deep.equal []
+
+		it "should send nothing to clientB", ->
+			@clientBUpdates.should.deep.equal []
+
+		it "should send an ack to clientC", ->
+			@clientCUpdates.should.deep.equal [{
+				v: @version, doc: @doc_id_second
+			}]
+
+	describe "with an error for the first project", ->
+		beforeEach (done) ->
 			rclient.publish "applied-ops", JSON.stringify({doc_id: @doc_id, error: @error = "something went wrong"})
 			setTimeout done, 200 # Give clients time to get message
-			
-		it "should send the error to both clients", ->
+
+		it "should send the error to the clients in the first project", ->
 			@clientAErrors.should.deep.equal [@error]
 			@clientBErrors.should.deep.equal [@error]
-			
-		it "should disconnect the clients", ->
+
+		it "should not send any errors to the client in the second project", ->
+			@clientCErrors.should.deep.equal []
+
+		it "should disconnect the clients of the first project", ->
 			@clientA.socket.connected.should.equal false
 			@clientB.socket.connected.should.equal false
+
+		it "should not disconnect the client in the second project", ->
+			@clientC.socket.connected.should.equal true
+
+	describe "with an error for the second project", ->
+		beforeEach (done) ->
+			rclient.publish "applied-ops", JSON.stringify({doc_id: @doc_id_second, error: @error = "something went wrong"})
+			setTimeout done, 200 # Give clients time to get message
+
+		it "should not send any errors to the clients in the first project", ->
+			@clientAErrors.should.deep.equal []
+			@clientBErrors.should.deep.equal []
+
+		it "should send the error to the client in the second project", ->
+			@clientCErrors.should.deep.equal [@error]
+
+		it "should not disconnect the clients of the first project", ->
+			@clientA.socket.connected.should.equal true
+			@clientB.socket.connected.should.equal true
+
+		it "should disconnect the client in the second project", ->
+			@clientC.socket.connected.should.equal false


### PR DESCRIPTION
### Description
This PR extends the `ReceiveUpdateTests` in adding a 2nd project and a 3rd user that joins this 2nd project but not the first one.

The intend is to check for cross project leaks from the message fan-out.

Sending messages and errors from doc-updater is tested -- the errors are paired with a disconnect.

#### Related Issues / PRs
https://github.com/overleaf/issues/issues/2757

#### Potential Impact
Affects tests only.
