### PR TITLE
[misc] test/acceptance: add tests for the draining of connections

### DIFF
--- a/test/acceptance/coffee/DrainManagerTests.coffee
+++ b/test/acceptance/coffee/DrainManagerTests.coffee
@@ -1,0 +1,72 @@
+RealTimeClient = require "./helpers/RealTimeClient"
+FixturesManager = require "./helpers/FixturesManager"
+
+expect = require("chai").expect
+
+async = require "async"
+request = require "request"
+
+Settings = require "settings-sharelatex"
+
+drain = (rate, callback) ->
+	request.post {
+		url: "http://localhost:3026/drain?rate=#{rate}"
+		auth: {
+			user: Settings.internal.realTime.user,
+			pass: Settings.internal.realTime.pass
+		}
+	}, (error, response, data) ->
+		callback error, data
+	return null
+
+describe "DrainManagerTests", ->
+	before (done) ->
+		FixturesManager.setUpProject {
+			privilegeLevel: "owner"
+			project: {
+				name: "Test Project"
+			}
+		}, (e, {@project_id, @user_id}) => done()
+		return null
+
+	describe "with two clients in the project", ->
+		beforeEach (done) ->
+			async.series [
+				(cb) =>
+					@clientA = RealTimeClient.connect()
+					@clientA.on "connectionAccepted", cb
+
+				(cb) =>
+					@clientB = RealTimeClient.connect()
+					@clientB.on "connectionAccepted", cb
+
+				(cb) =>
+					@clientA.emit "joinProject", project_id: @project_id, cb
+
+				(cb) =>
+					@clientB.emit "joinProject", project_id: @project_id, cb
+			], done
+
+		describe "starting to drain", () ->
+			# there is an internal delay of 1000ms, shift accordingly
+			@timeout(5000)
+			beforeEach (done) ->
+				async.parallel [
+					(cb) =>
+						@clientA.on "reconnectGracefully", cb
+					(cb) =>
+						@clientB.on "reconnectGracefully", cb
+
+					(cb) -> drain(2, cb)
+				], done
+
+			afterEach (done) ->
+				# reset drain
+				drain(0, done)
+
+			it "should not timeout", ->
+				expect(true).to.equal(true)
+
+			it "should not have disconnected", ->
+				expect(@clientA.socket.connected).to.equal true
+				expect(@clientB.socket.connected).to.equal true


### PR DESCRIPTION
### Description

This PR adds tests for logic of the DrainManager.

There are other clients connected but there is no api endpoint to disconnect them at this time.
I do have patches available that implement this and will schedule them after this PR.
We can then lower the timeout in line 52 as the drain will schedule the reconnect for the two clients immediately -- currently the clients from other tests are asked to reconnect too, and there is a 1s delay in between the drain runs.

#### Related Issues / PRs
https://github.com/overleaf/issues/issues/2757


#### Potential Impact
Affects tests only.
