### PR TITLE
[misc] test/acceptance: use helpers for unified socket.io client access

### DIFF
--- a/test/acceptance/coffee/ApplyUpdateTests.coffee
+++ b/test/acceptance/coffee/ApplyUpdateTests.coffee
@@ -5,6 +5,7 @@ chai.should()
 
 RealTimeClient = require "./helpers/RealTimeClient"
 FixturesManager = require "./helpers/FixturesManager"
+{getClientId, expectClientIsDisconnected} = require "./helpers/SocketIoUtils"
 
 settings = require "settings-sharelatex"
 redis = require "redis-sharelatex"
@@ -55,7 +56,7 @@ describe "applyOtUpdate", ->
 				update = JSON.parse(update)
 				update.op.should.deep.equal @update.op
 				update.meta.should.deep.equal {
-					source: @client.socket.sessionid
+					source: getClientId(@client)
 					user_id: @user_id
 				}
 				done()
@@ -101,7 +102,7 @@ describe "applyOtUpdate", ->
 		
 		it "should disconnect the client", (done) ->
 			setTimeout () =>
-				@client.socket.connected.should.equal false
+				expectClientIsDisconnected(@client)
 				done()
 			, 300
 			
@@ -152,7 +153,7 @@ describe "applyOtUpdate", ->
 				update = JSON.parse(update)
 				update.op.should.deep.equal @comment_update.op
 				update.meta.should.deep.equal {
-					source: @client.socket.sessionid
+					source: getClientId(@client)
 					user_id: @user_id
 				}
 				done()

--- a/test/acceptance/coffee/ClientTrackingTests.coffee
+++ b/test/acceptance/coffee/ClientTrackingTests.coffee
@@ -5,6 +5,7 @@ chai.should()
 RealTimeClient = require "./helpers/RealTimeClient"
 MockWebServer = require "./helpers/MockWebServer"
 FixturesManager = require "./helpers/FixturesManager"
+{getClientId} = require "./helpers/SocketIoUtils"
 
 async = require "async"
 
@@ -63,7 +64,7 @@ describe "clientTracking", ->
 					row: @row
 					column: @column
 					doc_id: @doc_id
-					id: @clientA.socket.sessionid
+					id: getClientId(@clientA)
 					user_id: @user_id
 					name: "Joe Bloggs"
 				}
@@ -72,7 +73,7 @@ describe "clientTracking", ->
 		it "should record the update in getConnectedUsers", (done) ->
 			@clientB.emit "clientTracking.getConnectedUsers", (error, users) =>
 				for user in users
-					if user.client_id == @clientA.socket.sessionid
+					if user.client_id == getClientId(@clientA)
 						expect(user.cursorData).to.deep.equal({
 							row: @row
 							column: @column
@@ -139,7 +140,7 @@ describe "clientTracking", ->
 					row: @row
 					column: @column
 					doc_id: @doc_id
-					id: @anonymous.socket.sessionid
+					id: getClientId(@anonymous)
 					user_id: "anonymous-user"
 					name: ""
 				}

--- a/test/acceptance/coffee/DrainManagerTests.coffee
+++ b/test/acceptance/coffee/DrainManagerTests.coffee
@@ -1,5 +1,6 @@
 RealTimeClient = require "./helpers/RealTimeClient"
 FixturesManager = require "./helpers/FixturesManager"
+{getClientId, expectClientIsConnected} = require "./helpers/SocketIoUtils"
 
 expect = require("chai").expect
 
@@ -68,5 +69,5 @@ describe "DrainManagerTests", ->
 				expect(true).to.equal(true)
 
 			it "should not have disconnected", ->
-				expect(@clientA.socket.connected).to.equal true
-				expect(@clientB.socket.connected).to.equal true
+				expectClientIsConnected(@clientA)
+				expectClientIsConnected(@clientB)

--- a/test/acceptance/coffee/JoinDocTests.coffee
+++ b/test/acceptance/coffee/JoinDocTests.coffee
@@ -5,6 +5,7 @@ chai.should()
 RealTimeClient = require "./helpers/RealTimeClient"
 MockDocUpdaterServer = require "./helpers/MockDocUpdaterServer"
 FixturesManager = require "./helpers/FixturesManager"
+{getClientId} = require "./helpers/SocketIoUtils"
 
 async = require "async"
 
@@ -48,7 +49,7 @@ describe "joinDoc", ->
 			@returnedArgs.should.deep.equal [@lines, @version, @ops, @ranges]
 			
 		it "should have joined the doc room", (done) ->
-			RealTimeClient.getConnectedClient @client.socket.sessionid, (error, client) =>
+			RealTimeClient.getConnectedClient getClientId(@client), (error, client) =>
 				expect(@doc_id in client.rooms).to.equal true
 				done()
 		
@@ -85,7 +86,7 @@ describe "joinDoc", ->
 			@returnedArgs.should.deep.equal [@lines, @version, @ops, @ranges]
 			
 		it "should have joined the doc room", (done) ->
-			RealTimeClient.getConnectedClient @client.socket.sessionid, (error, client) =>
+			RealTimeClient.getConnectedClient getClientId(@client), (error, client) =>
 				expect(@doc_id in client.rooms).to.equal true
 				done()
 		
@@ -122,7 +123,7 @@ describe "joinDoc", ->
 			@returnedArgs.should.deep.equal [@lines, @version, @ops, @ranges]
 			
 		it "should have joined the doc room", (done) ->
-			RealTimeClient.getConnectedClient @client.socket.sessionid, (error, client) =>
+			RealTimeClient.getConnectedClient getClientId(@client), (error, client) =>
 				expect(@doc_id in client.rooms).to.equal true
 				done()
 
@@ -164,7 +165,7 @@ describe "joinDoc", ->
 			@returnedArgs.should.deep.equal [@lines, @version, @ops, @ranges]
 			
 		it "should have joined the doc room", (done) ->
-			RealTimeClient.getConnectedClient @client.socket.sessionid, (error, client) =>
+			RealTimeClient.getConnectedClient getClientId(@client), (error, client) =>
 				expect(@doc_id in client.rooms).to.equal true
 				done()
 
@@ -202,7 +203,7 @@ describe "joinDoc", ->
 			@returnedArgs.should.deep.equal [@lines, @version, @ops, @ranges]
 
 		it "should have joined the doc room", (done) ->
-			RealTimeClient.getConnectedClient @client.socket.sessionid, (error, client) =>
+			RealTimeClient.getConnectedClient getClientId(@client), (error, client) =>
 				expect(@doc_id in client.rooms).to.equal true
 				done()
 
@@ -241,6 +242,6 @@ describe "joinDoc", ->
 			@returnedArgs.should.deep.equal [@lines, @version, @ops, @ranges]
 
 		it "should have joined the doc room", (done) ->
-			RealTimeClient.getConnectedClient @client.socket.sessionid, (error, client) =>
+			RealTimeClient.getConnectedClient getClientId(@client), (error, client) =>
 				expect(@doc_id in client.rooms).to.equal true
 				done()

--- a/test/acceptance/coffee/JoinProjectTests.coffee
+++ b/test/acceptance/coffee/JoinProjectTests.coffee
@@ -5,6 +5,7 @@ chai.should()
 RealTimeClient = require "./helpers/RealTimeClient"
 MockWebServer = require "./helpers/MockWebServer"
 FixturesManager = require "./helpers/FixturesManager"
+{getClientId} = require "./helpers/SocketIoUtils"
 
 async = require "async"
 
@@ -47,7 +48,7 @@ describe "joinProject", ->
 			@protocolVersion.should.equal 2
 			
 		it "should have joined the project room", (done) ->
-			RealTimeClient.getConnectedClient @client.socket.sessionid, (error, client) =>
+			RealTimeClient.getConnectedClient getClientId(@client), (error, client) =>
 				expect(@project_id in client.rooms).to.equal true
 				done()
 				
@@ -55,7 +56,7 @@ describe "joinProject", ->
 			@client.emit "clientTracking.getConnectedUsers", (error, users) =>
 				connected = false
 				for user in users
-					if user.client_id == @client.socket.sessionid and user.user_id == @user_id
+					if user.client_id == getClientId(@client) and user.user_id == @user_id
 						connected = true
 						break
 				expect(connected).to.equal true
@@ -86,7 +87,7 @@ describe "joinProject", ->
 			@error.message.should.equal "not authorized"
 			
 		it "should not have joined the project room", (done) ->
-			RealTimeClient.getConnectedClient @client.socket.sessionid, (error, client) =>
+			RealTimeClient.getConnectedClient getClientId(@client), (error, client) =>
 				expect(@project_id in client.rooms).to.equal false
 				done()
 

--- a/test/acceptance/coffee/LeaveDocTests.coffee
+++ b/test/acceptance/coffee/LeaveDocTests.coffee
@@ -6,6 +6,8 @@ sinon = require("sinon")
 RealTimeClient = require "./helpers/RealTimeClient"
 MockDocUpdaterServer = require "./helpers/MockDocUpdaterServer"
 FixturesManager = require "./helpers/FixturesManager"
+{getClientId} = require "./helpers/SocketIoUtils"
+
 logger = require("logger-sharelatex")
 
 async = require "async"
@@ -54,7 +56,7 @@ describe "leaveDoc", ->
 					done()
 			
 			it "should have left the doc room", (done) ->
-				RealTimeClient.getConnectedClient @client.socket.sessionid, (error, client) =>
+				RealTimeClient.getConnectedClient getClientId(@client), (error, client) =>
 					expect(@doc_id in client.rooms).to.equal false
 					done()
 
@@ -71,7 +73,7 @@ describe "leaveDoc", ->
 					sinon.assert.neverCalledWith(logger.error, sinon.match.any, "not subscribed - shouldn't happen")
 
 				it "should have left the doc room", (done) ->
-					RealTimeClient.getConnectedClient @client.socket.sessionid, (error, client) =>
+					RealTimeClient.getConnectedClient getClientId(@client), (error, client) =>
 						expect(@doc_id in client.rooms).to.equal false
 						done()
 

--- a/test/acceptance/coffee/LeaveProjectTests.coffee
+++ b/test/acceptance/coffee/LeaveProjectTests.coffee
@@ -1,6 +1,7 @@
 RealTimeClient = require "./helpers/RealTimeClient"
 MockDocUpdaterServer = require "./helpers/MockDocUpdaterServer"
 FixturesManager = require "./helpers/FixturesManager"
+{getClientId} = require "./helpers/SocketIoUtils"
 
 async = require "async"
 
@@ -27,7 +28,7 @@ describe "leaveProject", ->
 					@clientA = RealTimeClient.connect()
 					@clientA.on "connectionAccepted", () =>
 						# may be cleaned up after disconnect
-						@clientA_id = @clientA.socket.sessionid
+						@clientA_id = getClientId(@clientA)
 						cb()
 					
 				(cb) =>

--- a/test/acceptance/coffee/ReceiveUpdateTests.coffee
+++ b/test/acceptance/coffee/ReceiveUpdateTests.coffee
@@ -5,6 +5,7 @@ chai.should()
 RealTimeClient = require "./helpers/RealTimeClient"
 MockWebServer = require "./helpers/MockWebServer"
 FixturesManager = require "./helpers/FixturesManager"
+{getClientId, expectClientIsConnected, expectClientIsDisconnected} = require "./helpers/SocketIoUtils"
 
 async = require "async"
 
@@ -102,7 +103,7 @@ describe "receiveUpdate", ->
 				doc_id: @doc_id
 				op:
 					meta:
-						source: @clientA.socket.sessionid
+						source: getClientId(@clientA)
 					v: @version
 					doc: @doc_id
 					op: [{i: "foo", p: 50}]				
@@ -127,7 +128,7 @@ describe "receiveUpdate", ->
 				doc_id: @doc_id_second
 				op:
 					meta:
-						source: @clientC.socket.sessionid
+						source: getClientId(@clientC)
 					v: @version
 					doc: @doc_id_second
 					op: [{i: "update from clientC", p: 50}]
@@ -159,11 +160,11 @@ describe "receiveUpdate", ->
 			@clientCErrors.should.deep.equal []
 
 		it "should disconnect the clients of the first project", ->
-			@clientA.socket.connected.should.equal false
-			@clientB.socket.connected.should.equal false
+			expectClientIsDisconnected(@clientA)
+			expectClientIsDisconnected(@clientB)
 
 		it "should not disconnect the client in the second project", ->
-			@clientC.socket.connected.should.equal true
+			expectClientIsConnected(@clientC)
 
 	describe "with an error for the second project", ->
 		beforeEach (done) ->
@@ -178,8 +179,8 @@ describe "receiveUpdate", ->
 			@clientCErrors.should.deep.equal [@error]
 
 		it "should not disconnect the clients of the first project", ->
-			@clientA.socket.connected.should.equal true
-			@clientB.socket.connected.should.equal true
+			expectClientIsConnected(@clientA)
+			expectClientIsConnected(@clientB)
 
 		it "should disconnect the client in the second project", ->
-			@clientC.socket.connected.should.equal false
+			expectClientIsDisconnected(@clientC)

--- a/test/acceptance/coffee/SessionTests.coffee
+++ b/test/acceptance/coffee/SessionTests.coffee
@@ -2,6 +2,7 @@ chai = require("chai")
 expect = chai.expect
 
 RealTimeClient = require "./helpers/RealTimeClient"
+{getClientId} = require "./helpers/SocketIoUtils"
 
 describe "Session", ->
 	describe "with an established session", ->
@@ -31,7 +32,7 @@ describe "Session", ->
 			RealTimeClient.getConnectedClients (error, clients) =>
 				included = false
 				for client in clients
-					if client.client_id == @client.socket.sessionid
+					if client.client_id == getClientId(@client)
 						included = true
 						break
 				expect(included).to.equal true

--- a/test/acceptance/coffee/helpers/SocketIoUtils.coffee
+++ b/test/acceptance/coffee/helpers/SocketIoUtils.coffee
@@ -1,0 +1,11 @@
+{expect} = require("chai")
+
+module.exports =
+	getClientId: (client) ->
+		return client.socket.sessionid
+
+	expectClientIsConnected: (client) ->
+		expect(client.socket.connected).to.equal(true)
+
+	expectClientIsDisconnected: (client) ->
+		expect(client.socket.connected).to.equal(false)


### PR DESCRIPTION
### Description

This is in preparation for the socket.io upgrade with breaking changes in the client API.

I am proposing to abstract some of the client access into helper functions. Upon upgrading the version, only the helper function will need changes and the rest of the tests remain unchanged, easing code review.

#### Related Issues / PRs
https://github.com/overleaf/issues/issues/2757

#### Potential Impact
Affects tests only.
