### PR TITLE
[misc] test/acceptance: silence the logger

### DIFF
--- a/test/acceptance/coffee/helpers/RealtimeServer.coffee
+++ b/test/acceptance/coffee/helpers/RealtimeServer.coffee
@@ -1,5 +1,4 @@
 app = require('../../../../app')
-require("logger-sharelatex").logger.level("info")
 logger = require("logger-sharelatex")
 Settings = require("settings-sharelatex")
 


### PR DESCRIPTION
### Description

The acceptance tests are very verbose, even tho `LOG_LEVEL` is set to `ERROR` in the docker-compose files. This is due to a hard coded override to `LOG_LEVEL=INFO` in a (broken [1]) acceptance tests helper.

This PR proposes to remove the hard coded value and let's the developer set the level depending on their needs via the docker-compose files.

#### Potential Impact
Affects tests only.

---
[1] we do not export the express app in `app.coffee`, hence all the logic in there is void.