### PR TITLE
[HttpController] return 404 in case of a missing client

### DIFF
--- a/app/coffee/HttpController.coffee
+++ b/app/coffee/HttpController.coffee
@@ -30,8 +30,10 @@ module.exports = HttpController =
 	getConnectedClient: (req, res, next) ->
 		{client_id} = req.params
 		io = req.app.get("io")
-		ioClient = io.sockets.socket(client_id)
+		ioClient = io.sockets.sockets[client_id]
+		if !ioClient
+			res.sendStatus(404)
+			return
 		HttpController._getConnectedClientView ioClient, (error, client) ->
 			return next(error) if error?
 			res.json client
-		

--- a/test/acceptance/coffee/HttpControllerTests.coffee
+++ b/test/acceptance/coffee/HttpControllerTests.coffee
@@ -1,0 +1,69 @@
+async = require('async')
+expect = require('chai').expect
+request = require('request').defaults({
+	baseUrl: 'http://localhost:3026'
+})
+
+RealTimeClient = require "./helpers/RealTimeClient"
+FixturesManager = require "./helpers/FixturesManager"
+{getClientId} = require "./helpers/SocketIoUtils"
+
+describe 'HttpControllerTests', ->
+	describe 'without a user', ->
+		it 'should return 404 for the client view', (done) ->
+			client_id = 'not-existing'
+			request.get {
+				url: "/clients/#{client_id}"
+				json: true
+			}, (error, response, data) ->
+				return done(error) if error
+				expect(response.statusCode).to.equal(404)
+				done()
+
+	describe 'with a user and after joining a project', ->
+		before (done) ->
+			async.series [
+				(cb) =>
+					FixturesManager.setUpProject {
+						privilegeLevel: "owner"
+					}, (error, {@project_id, @user_id}) =>
+						cb(error)
+
+				(cb) =>
+					FixturesManager.setUpDoc @project_id, {}, (error, {@doc_id}) =>
+						cb(error)
+
+				(cb) =>
+					@client = RealTimeClient.connect()
+					@client.on "connectionAccepted", cb
+
+				(cb) =>
+					@client.emit "joinProject", {@project_id}, cb
+
+				(cb) =>
+					@client.emit "joinDoc", @doc_id, cb
+			], done
+
+		it 'should send a client view', (done) ->
+			request.get {
+				url: "/clients/#{getClientId(@client)}"
+				json: true
+			}, (error, response, data) =>
+				return done(error) if error
+				expect(response.statusCode).to.equal(200)
+				expect(data.connected_time).to.exist
+				delete data.connected_time
+				# .email is not set in the session
+				delete data.email
+				expect(data).to.deep.equal({
+					client_id: getClientId(@client),
+					first_name: 'Joe',
+					last_name: 'Bloggs',
+					project_id: @project_id,
+					user_id: @user_id,
+					rooms: [
+						@project_id,
+						@doc_id,
+					]
+				})
+				done()


### PR DESCRIPTION
### Description
This is in preparation for the socket.io upgrade.

`client.rooms` includes the socket id/client id in socket.io v2. The added tests lock in the existing behavior of not including the id.

Non-existing clients yielded an empty client view previously [1]. I changed the behavior to return a status code of 404 instead.

#### Related Issues / PRs
https://github.com/overleaf/issues/issues/2757

#### Potential Impact
Low, the client view route is used in acceptance tests and might be used for debugging

---
[1] `io.sockets.socket()` creates a new Socket instance in case it can not find an existing for the provided id. This Socket instance is likely never freed, creating a memory leak when debugging in production. https://github.com/socketio/socket.io/blob/41b9a7e45d62ead3b4b36dc38cc8c03882ecc577/lib/namespace.js#L202-L208