### PR TITLE
[perf] test/acceptance: DrainManagerTests: cleanup previous clients

### DIFF
--- a/app/coffee/HttpApiController.coffee
+++ b/app/coffee/HttpApiController.coffee
@@ -19,3 +19,17 @@ module.exports = HttpApiController =
 		logger.log {rate}, "setting client drain rate"
 		DrainManager.startDrain io, rate
 		res.send 204
+
+	disconnectClient: (req, res, next) ->
+		io = req.app.get("io")
+		client_id = req.params.client_id
+		client = io.sockets.sockets[client_id]
+
+		if !client
+			logger.info({client_id}, "api: client already disconnected")
+			res.sendStatus(404)
+			return
+		logger.warn({client_id}, "api: requesting client disconnect")
+		client.on "disconnect", () ->
+			res.sendStatus(204)
+		client.disconnect()

--- a/app/coffee/Router.coffee
+++ b/app/coffee/Router.coffee
@@ -40,6 +40,7 @@ module.exports = Router =
 		app.post "/project/:project_id/message/:message", httpAuth, bodyParser.json(limit: "5mb"), HttpApiController.sendMessage
 		
 		app.post "/drain", httpAuth, HttpApiController.startDrain
+		app.post "/client/:client_id/disconnect", httpAuth, HttpApiController.disconnectClient
 
 		session.on 'connection', (error, client, session) ->
 			client?.on "error", (err) ->

--- a/test/acceptance/coffee/DrainManagerTests.coffee
+++ b/test/acceptance/coffee/DrainManagerTests.coffee
@@ -30,6 +30,18 @@ describe "DrainManagerTests", ->
 		}, (e, {@project_id, @user_id}) => done()
 		return null
 
+	before (done) ->
+		# cleanup to speedup reconnecting
+		@timeout(10000)
+		RealTimeClient.disconnectAllClients done
+
+	# trigger and check cleanup
+	it "should have disconnected all previous clients", (done) ->
+		RealTimeClient.getConnectedClients (error, data) ->
+			return done(error) if error
+			expect(data.length).to.equal(0)
+			done()
+
 	describe "with two clients in the project", ->
 		beforeEach (done) ->
 			async.series [
@@ -49,8 +61,6 @@ describe "DrainManagerTests", ->
 			], done
 
 		describe "starting to drain", () ->
-			# there is an internal delay of 1000ms, shift accordingly
-			@timeout(5000)
 			beforeEach (done) ->
 				async.parallel [
 					(cb) =>

--- a/test/acceptance/coffee/helpers/RealTimeClient.coffee
+++ b/test/acceptance/coffee/helpers/RealTimeClient.coffee
@@ -1,5 +1,6 @@
 XMLHttpRequest = require("../../libs/XMLHttpRequest").XMLHttpRequest
 io = require("socket.io-client")
+async = require("async")
 
 request = require "request"
 Settings = require "settings-sharelatex"
@@ -55,3 +56,20 @@ module.exports = Client =
 		}, (error, response, data) ->
 			callback error, data
 		return null
+
+	disconnectClient: (client_id, callback) ->
+		request.post {
+			url: "http://localhost:3026/client/#{client_id}/disconnect"
+			auth: {
+				user: Settings.internal.realTime.user,
+				pass: Settings.internal.realTime.pass
+			}
+		}, (error, response, data) ->
+			callback error, data
+		return null
+
+	disconnectAllClients: (callback) ->
+		Client.getConnectedClients (error, clients) ->
+			async.each clients, (clientView, cb) ->
+				Client.disconnectClient clientView.client_id, cb
+			, callback


### PR DESCRIPTION
### Description

This is the suggested followup PR for https://github.com/overleaf/real-time/pull/108

It implements the http api routes for disconnecting a single client, paired with acceptance tests helper to disconnect all clients.

This functionality is then used to cleanup previous clients before starting to drain/reconnect clients.
The DrainManager can reconnect the clients of the DrainManagerTests immediately and does not have to cycle through all the other clients before them.
We can drop the added timeout spec for the individual DrainManagerTest cases now.

#### Related Issues / PRs
https://github.com/overleaf/real-time/pull/108
https://github.com/overleaf/issues/issues/2757

#### Potential Impact
Low, added functionality and changes tests
