### PR TITLE
[perf] WebsocketLoadBalancer: move back to a sync loop for msg fan out

### DIFF
--- a/app/coffee/WebsocketLoadBalancer.coffee
+++ b/app/coffee/WebsocketLoadBalancer.coffee
@@ -7,7 +7,6 @@ HealthCheckManager = require "./HealthCheckManager"
 RoomManager = require "./RoomManager"
 ChannelManager = require "./ChannelManager"
 ConnectedUsersManager = require "./ConnectedUsersManager"
-Async = require 'async'
 
 RESTRICTED_USER_MESSAGE_TYPE_PASS_LIST = [
 	'connectionAccepted',
@@ -96,17 +95,10 @@ module.exports = WebsocketLoadBalancer =
 					socketIoClients: (client.id for client in clientList)
 				}, "distributing event to clients"
 				seen = {}
-				# Send the messages to clients async, don't wait for them all to finish
-				Async.eachLimit clientList
-					, 2
-					, (client, cb) ->
+				for client in clientList
 							if !seen[client.id]
 								seen[client.id] = true
 								client.emit(message.message, message.payload...)
-							cb()
-					, (err) ->
-						if err?
-							logger.err {err, message}, "Error sending message to clients"
 			else if message.health_check?
 				logger.debug {message}, "got health check message in editor events channel"
 				HealthCheckManager.check channel, message.key


### PR DESCRIPTION
### Description
Followup from https://github.com/overleaf/real-time/pull/113#discussion_r384380729

This PR removes the overhead from using `async.eachLimit` when a simple synchronous loop works too.

_Previously there were async operations happening inside the loop, which required the use of `async.eachLimit` to limit the number of concurrent actions._

#### Related Issues / PRs
https://github.com/overleaf/real-time/pull/113
https://github.com/overleaf/issues/issues/2757

