### PR TITLE
[misc] let proxys observe an upcoming shutdown before starting to drain

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -125,9 +125,14 @@ drainAndShutdown = (signal) ->
 		return
 	else
 		Settings.shutDownInProgress = true
-		logger.warn signal: signal, "received interrupt, starting drain over #{shutdownDrainTimeWindow} mins"
-		DrainManager.startDrainTimeWindow(io, shutdownDrainTimeWindow)
-		shutdownCleanly(signal)
+		statusCheckInterval = Settings.statusCheckInterval
+		if statusCheckInterval
+			logger.warn signal: signal, "received interrupt, delay drain by #{statusCheckInterval}ms"
+		setTimeout () ->
+			logger.warn signal: signal, "received interrupt, starting drain over #{shutdownDrainTimeWindow} mins"
+			DrainManager.startDrainTimeWindow(io, shutdownDrainTimeWindow)
+			shutdownCleanly(signal)
+		, statusCheckInterval
 
 
 Settings.shutDownInProgress = false

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -60,6 +60,8 @@ settings =
 	
 	publishOnIndividualChannels: process.env['PUBLISH_ON_INDIVIDUAL_CHANNELS'] or false
 
+	statusCheckInterval: parseInt(process.env['STATUS_CHECK_INTERVAL'] or '0')
+
 	sentry:
 		dsn: process.env.SENTRY_DSN
 


### PR DESCRIPTION
### Description

As per the title. Proxys in front of `real-time` may poll the health status and push traffic to the pod until it shows a failing state. Reconnect requests should not go to the same pod. We have to wait for the proxy to observe that a given pod is going down soon, before we can start with draining.

Default is do not delay the draining. Adjust via the environment variable `STATUS_CHECK_INTERVAL`.

#### Related Issues / PRs
https://github.com/overleaf/dev-environment/pull/324

#### Potential Impact
Low

#### Manual Testing Performed

- see https://github.com/overleaf/dev-environment/pull/324
