### PR TITLE
[misc] limit update size

### DIFF
--- a/app/coffee/DocumentUpdaterManager.coffee
+++ b/app/coffee/DocumentUpdaterManager.coffee
@@ -61,9 +61,17 @@ module.exports = DocumentUpdaterManager =
 		change = _.pick change, allowedKeys
 		jsonChange = JSON.stringify change
 		if jsonChange.indexOf("\u0000") != -1
+			# memory corruption check
 			error = new Error("null bytes found in op")
 			logger.error err: error, project_id: project_id, doc_id: doc_id, jsonChange: jsonChange, error.message
 			return callback(error)
+
+		updateSize = jsonChange.length
+		if updateSize > settings.maxUpdateSize
+			error = new Error("update is too large")
+			error.updateSize = updateSize
+			return callback(error)
+
 		doc_key = "#{project_id}:#{doc_id}"
 		# Push onto pendingUpdates for doc_id first, because once the doc updater
 		# gets an entry on pending-updates-list, it starts processing.

--- a/app/coffee/SafeJsonParse.coffee
+++ b/app/coffee/SafeJsonParse.coffee
@@ -3,8 +3,8 @@ logger = require "logger-sharelatex"
 
 module.exports =
 	parse: (data, callback = (error, parsed) ->) ->
-		if data.length > (Settings.max_doc_length or 2 * 1024 * 1024)
-			logger.error {head: data.slice(0,1024)}, "data too large to parse"
+		if data.length > Settings.maxUpdateSize
+			logger.error {head: data.slice(0,1024), length: data.length}, "data too large to parse"
 			return callback new Error("data too large to parse")
 		try
 			parsed = JSON.parse(data)

--- a/app/coffee/WebsocketController.coffee
+++ b/app/coffee/WebsocketController.coffee
@@ -204,22 +204,6 @@ module.exports = WebsocketController =
 			return callback(error) if error?
 			return callback(new Error("no project_id found on client")) if !project_id?
 
-			updateSize = JSON.stringify(update).length
-			if updateSize > settings.maxUpdateSize
-				metrics.inc "update_too_large"
-				logger.warn({user_id, project_id, doc_id, updateSize}, "update is too large")
-
-				# mark the update as received -- the client should not send it again!
-				callback()
-
-				# trigger an out-of-sync error
-				message = {project_id, doc_id, error: "update is too large"}
-				setTimeout () ->
-					client.emit "otUpdateError", message.error, message
-					client.disconnect()
-				, 100
-				return
-
 			WebsocketController._assertClientCanApplyUpdate client, doc_id, update, (error) ->
 				if error?
 					logger.warn {err: error, doc_id, client_id: client.id, version: update.v}, "client is not authorized to make update"
@@ -236,6 +220,22 @@ module.exports = WebsocketController =
 				logger.log {user_id, doc_id, project_id, client_id: client.id, version: update.v}, "sending update to doc updater"
 
 				DocumentUpdaterManager.queueChange project_id, doc_id, update, (error) ->
+					if error?.message == "update is too large"
+						metrics.inc "update_too_large"
+						updateSize = error.updateSize
+						logger.warn({user_id, project_id, doc_id, updateSize}, "update is too large")
+
+						# mark the update as received -- the client should not send it again!
+						callback()
+
+						# trigger an out-of-sync error
+						message = {project_id, doc_id, error: "update is too large"}
+						setTimeout () ->
+							client.emit "otUpdateError", message.error, message
+							client.disconnect()
+						, 100
+						return
+
 					if error?
 						logger.error {err: error, project_id, doc_id, client_id: client.id, version: update.v}, "document was not available for update"
 						client.disconnect()

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -52,6 +52,11 @@ settings =
 	
 	max_doc_length: 2 * 1024 * 1024 # 2mb
 
+	# combine
+	# max_doc_length (2mb see above) * 2 (delete + insert)
+	# max_ranges_size (3mb see MAX_RANGES_SIZE in doc-updater) 
+	maxUpdateSize: parseInt(process.env['MAX_UPDATE_SIZE']) or 7 * 1024 * 1024
+
 	shutdownDrainTimeWindow: process.env['SHUTDOWN_DRAIN_TIME_WINDOW'] or 9
 
 	continualPubsubTraffic: process.env['CONTINUAL_PUBSUB_TRAFFIC'] or false

--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -54,8 +54,9 @@ settings =
 
 	# combine
 	# max_doc_length (2mb see above) * 2 (delete + insert)
-	# max_ranges_size (3mb see MAX_RANGES_SIZE in doc-updater) 
-	maxUpdateSize: parseInt(process.env['MAX_UPDATE_SIZE']) or 7 * 1024 * 1024
+	# max_ranges_size (3mb see MAX_RANGES_SIZE in document-updater)
+	# overhead for JSON serialization
+	maxUpdateSize: parseInt(process.env['MAX_UPDATE_SIZE']) or 7 * 1024 * 1024 + 64 * 1024
 
 	shutdownDrainTimeWindow: process.env['SHUTDOWN_DRAIN_TIME_WINDOW'] or 9
 

--- a/test/acceptance/coffee/ApplyUpdateTests.coffee
+++ b/test/acceptance/coffee/ApplyUpdateTests.coffee
@@ -71,8 +71,10 @@ describe "applyOtUpdate", ->
 	describe "when authorized with a huge edit update", ->
 		before (done) ->
 			@update = {
-				op: {p: 12, t: "foo"},
-				junk: 'this update is too large'.repeat(1024 * 300) # >7MB
+				op: {
+					p: 12,
+					t: "update is too large".repeat(1024 * 400) # >7MB
+				}
 			}
 			async.series [
 				(cb) =>

--- a/test/unit/coffee/SafeJsonParseTest.coffee
+++ b/test/unit/coffee/SafeJsonParseTest.coffee
@@ -8,7 +8,7 @@ describe 'SafeJsonParse', ->
 	beforeEach ->
 		@SafeJsonParse = SandboxedModule.require modulePath, requires:
 			"settings-sharelatex": @Settings = {
-				max_doc_length: 16 * 1024
+				maxUpdateSize: 16 * 1024
 			}
 			"logger-sharelatex": @logger = {error: sinon.stub()}
 
@@ -27,7 +27,7 @@ describe 'SafeJsonParse', ->
 			# we have a 2k overhead on top of max size
 			big_blob = Array(16*1024).join("A")
 			data = "{\"foo\": \"#{big_blob}\"}"
-			@Settings.max_doc_length = 2 * 1024
+			@Settings.maxUpdateSize = 2 * 1024
 			@SafeJsonParse.parse data, (error, parsed) =>
 				@logger.error.called.should.equal true
 				expect(error).to.exist

--- a/test/unit/coffee/WebsocketControllerTests.coffee
+++ b/test/unit/coffee/WebsocketControllerTests.coffee
@@ -32,7 +32,6 @@ describe 'WebsocketController', ->
 			"./DocumentUpdaterManager": @DocumentUpdaterManager = {}
 			"./ConnectedUsersManager": @ConnectedUsersManager = {}
 			"./WebsocketLoadBalancer": @WebsocketLoadBalancer = {}
-			"settings-sharelatex": {maxUpdateSize: 7 * 1024 * 1024}
 			"logger-sharelatex": @logger = { log: sinon.stub(), error: sinon.stub(), warn: sinon.stub() }
 			"metrics-sharelatex": @metrics =
 				inc: sinon.stub()
@@ -673,12 +672,11 @@ describe 'WebsocketController', ->
 			beforeEach (done) ->
 				@client.disconnect = sinon.stub()
 				@client.emit = sinon.stub()
-				@update = {
-					op: {p: 12, t: "foo"},
-					junk: 'this update is too large'.repeat(1024 * 300) # >7MB
-				}
 				@client.params.user_id = @user_id
 				@client.params.project_id = @project_id
+				error = new Error("update is too large")
+				error.updateSize = 7372835
+				@DocumentUpdaterManager.queueChange = sinon.stub().callsArgWith(3, error)
 				@WebsocketController.applyOtUpdate @client, @doc_id, @update, @callback
 				setTimeout ->
 					done()


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

We should limit inbound socket.io traffic.

Large updates get pushed to redis, pulled by doc-updater and discarded then.
The frontend will not receive a confirmation for the update and will push the
 update again and again, until it gets disconnected by real-time when the
 rejection from doc-updater comes in as an 'otUpdateError'.

Related and also included in this PR:

We can push an update to doc-updater that is larger than a single doc is
 allowed to be (2mb). The confirmation from doc-updater would get rejected
however, the frontend will never see the confirmation and send the update
 again and again.

#### Review

The limit is set to two doc-sizes (delete and insert new full doc) plus the
 maximum size of ranges: 2*2mb + 3mb.

In theory we should add JSON encoding overhead to the limit.
But I could not find a way to max out the current limit to its full potential,
 meaning full 2mb doc replacement and generating 3mb worth of ranges,
 using our frontend -- and not a rough third-party client.

_Rejecting a 1.5mb range is blocked at the frontend with a doc-is-too-large
 and out-of-sync modal, real-time does not see the update -- bug?_

#### Potential Impact

High. 


#### Manual Testing Performed

I added unit/acceptance tests.

##### allowed

- create a payload of just below 2mb
- paste it into a project/document
- copy everything in the doc
- paste the payload over it (replace it)
- the update should be allowed

##### rejected

- repeat the previous steps in a loop
- eventually more than two payloads are in a single update

  (delete, insert, delete, insert)

- get an out-of-sync message

#### Metrics and Monitoring

new metric: `update_too_large`
https://github.com/overleaf/real-time/blob/7572a8a9504a13571a15fc466ff0f96924f351b1/app/coffee/WebsocketController.coffee#L207-L209
