### PR TITLE
add metric for pendingUpdates queue

### DIFF
--- a/app/coffee/DocumentUpdaterManager.coffee
+++ b/app/coffee/DocumentUpdaterManager.coffee
@@ -72,6 +72,9 @@ module.exports = DocumentUpdaterManager =
 			error.updateSize = updateSize
 			return callback(error)
 
+		# record metric for each update added to queue
+		metrics.summary 'redis.pendingUpdates', updateSize, {status: 'push'}
+
 		doc_key = "#{project_id}:#{doc_id}"
 		# Push onto pendingUpdates for doc_id first, because once the doc updater
 		# gets an entry on pending-updates-list, it starts processing.

--- a/test/unit/coffee/DocumentUpdaterManagerTests.coffee
+++ b/test/unit/coffee/DocumentUpdaterManagerTests.coffee
@@ -25,6 +25,7 @@ describe 'DocumentUpdaterManager', ->
 				'request': @request = {}
 				'redis-sharelatex' : createClient: () => @rclient
 				'metrics-sharelatex': @Metrics =
+					summary: sinon.stub()
 					Timer: class Timer
 						done: () ->
 			globals:


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Add queue throughput metric for pendingUpdates (added to queue)

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2882

and

https://github.com/overleaf/document-updater/pull/127


### Review

Adds metric only

#### Potential Impact

Low.  Realtime so any exception would be very bad.

#### Manual Testing Performed

- [x] Unit and acceptance tests

#### Accessibility

NA

### Deployment

Combine this with any other pending realtime deploys, to reduce the number of times we shift users onto a new realtime process.

#### Deployment Checklist

NA

#### Metrics and Monitoring

Add redis.pendingUpdates `push` metric to redis dashboard.

#### Who Needs to Know?

NA