### PR TITLE
[Router] gracefully set and do not reset the ol_context

### DIFF
--- a/app/coffee/Router.coffee
+++ b/app/coffee/Router.coffee
@@ -41,7 +41,9 @@ module.exports = Router =
 		app.post "/client/:client_id/disconnect", httpAuth, HttpApiController.disconnectClient
 
 		session.on 'connection', (error, client, session) ->
-			client.ol_context = {} unless client.ol_context
+			# init client context, we may access it in Router._handleError before
+			#  setting any values
+			client.ol_context = {}
 
 			client?.on "error", (err) ->
 				logger.err { clientErr: err }, "socket.io client error"

--- a/app/coffee/Router.coffee
+++ b/app/coffee/Router.coffee
@@ -41,7 +41,7 @@ module.exports = Router =
 		app.post "/client/:client_id/disconnect", httpAuth, HttpApiController.disconnectClient
 
 		session.on 'connection', (error, client, session) ->
-			client.ol_context = {}
+			client.ol_context = {} unless client.ol_context
 
 			client?.on "error", (err) ->
 				logger.err { clientErr: err }, "socket.io client error"
@@ -98,13 +98,9 @@ module.exports = Router =
 
 			client.on "disconnecting", () ->
 				# This is called just before leaving rooms.
-				cleanup = () ->
-					delete client.ol_context
 				WebsocketController.leaveProject io, client, (err) ->
 					if err?
-						Router._handleError cleanup, err, client, "leaveProject"
-					else
-						cleanup()
+						Router._handleError (() ->), err, client, "leaveProject"
 
 			# Variadic. The possible arguments:
 			# doc_id, callback

--- a/app/coffee/WebsocketController.coffee
+++ b/app/coffee/WebsocketController.coffee
@@ -26,6 +26,7 @@ module.exports = WebsocketController =
 				logger.warn {err, project_id, user_id, client_id: client.id}, "user is not authorized to join project"
 				return callback(err)
 
+			client.ol_context = {}
 			client.ol_context["privilege_level"] = privilegeLevel
 			client.ol_context["user_id"] = user_id
 			client.ol_context["project_id"] = project_id


### PR DESCRIPTION
### Description

For https://digital-science.slack.com/archives/G6Q45PYQL/p1587468755015700

There seem to be events coming in after the socket entered the 'disconnecting' state (before 'disconnect'). It should be OK to leave the `ol_context` on the client and let v8 clean it up as it destructs the client.

#### Potential Impact

Low, race condition see slack.
