### PR TITLE
[misc] bring back the safe guards when processing the .clients() result

### DIFF
--- a/app/coffee/DocumentUpdaterController.coffee
+++ b/app/coffee/DocumentUpdaterController.coffee
@@ -80,7 +80,7 @@ module.exports = DocumentUpdaterController =
 			if err?
 				return logger.err {room: doc_id, err}, "failed to get room clients"
 
-			for client in clientIds.map((id) -> io.sockets.connected[id])
+			for client in clientIds.map((id) -> io.sockets.connected[id]) when client # filter disconnected clients
 				logger.warn err: error, doc_id: doc_id, client_id: client.id, "error from document updater, disconnecting client"
 				client.emit "otUpdateError", error, message
 				client.disconnect()

--- a/app/coffee/WebsocketLoadBalancer.coffee
+++ b/app/coffee/WebsocketLoadBalancer.coffee
@@ -71,7 +71,7 @@ module.exports = WebsocketLoadBalancer =
 					if err?
 						return logger.err {room: message.room_id, err}, "failed to get room clients"
 					logger.log {channel:channel, message: message.message, room_id: message.room_id, message_id: message._id, socketIoClients: clientIds}, "refreshing client list"
-					for clientId in clientIds
+					for clientId in clientIds when io.sockets.connected[clientId] # filter disconnected clients
 						ConnectedUsersManager.refreshClient(message.room_id, clientId)
 			else if message.room_id?
 				if message._id? && Settings.checkEventOrder
@@ -86,6 +86,7 @@ module.exports = WebsocketLoadBalancer =
 
 					clientList = clientIds
 					.map((id) -> io.sockets.connected[id])
+					.filter(Boolean) # filter disconnected clients
 					.filter((client) ->
 						!(is_restricted_message && client.ol_context['is_restricted_user'])
 					)


### PR DESCRIPTION
#### Description

This reverts commit 8026003f8e9dab506d1a8a3e6e5f41188555a6bb

See this discussion:

https://github.com/overleaf/real-time/pull/117/files/818a3e509e5906a0d75b994b820cdef06fce68e2..be289b66821f1228a9bcdd6a29837c7cd8e62d64#r387073018

We assumed that `process.nextTick` would not allow for clients to 'disappear'/disconnect in between calling`io.clients(ROOM)`  and us processing the result synchronously.

https://digital-science.slack.com/archives/G6Q45PYQL/p1587634527021500 proved different.


#### Related Issues / PRs

https://github.com/overleaf/real-time/pull/117

#### Potential Impact

Low, added safe guard

