### PR TITLE
[misc] hack around process next tick

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[app/coffee/RoomManager.coffee]
+indent_style = space

--- a/app/coffee/DocumentUpdaterController.coffee
+++ b/app/coffee/DocumentUpdaterController.coffee
@@ -80,7 +80,7 @@ module.exports = DocumentUpdaterController =
 			if err?
 				return logger.err {room: doc_id, err}, "failed to get room clients"
 
-			for client in clientIds.map((id) -> io.sockets.connected[id]) when client # filter disconnected clients
+			for client in clientIds.map((id) -> io.sockets.connected[id])
 				logger.warn err: error, doc_id: doc_id, client_id: client.id, "error from document updater, disconnecting client"
 				client.emit "otUpdateError", error, message
 				client.disconnect()

--- a/app/coffee/DocumentUpdaterController.coffee
+++ b/app/coffee/DocumentUpdaterController.coffee
@@ -76,7 +76,7 @@ module.exports = DocumentUpdaterController =
 		(sender || io).to(doc_id).emit "otUpdateApplied", update
 
 	_processErrorFromDocumentUpdater: (io, doc_id, error, message) ->
-		io.to(doc_id).clients (err, clientIds) ->
+		RoomManager.getClientsInRoomPseudoAsync io, doc_id, (err, clientIds) ->
 			if err?
 				return logger.err {room: doc_id, err}, "failed to get room clients"
 

--- a/app/coffee/WebsocketController.coffee
+++ b/app/coffee/WebsocketController.coffee
@@ -74,7 +74,7 @@ module.exports = WebsocketController =
 
 			RoomManager.leaveProjectAndDocs(client)
 			setTimeout () ->
-				io.in(project_id).clients (error, remainingClients) ->
+				RoomManager.getClientsInRoomPseudoAsync io, project_id, (error, remainingClients) ->
 					if remainingClients.length == 0
 						# Flush project in the background
 						DocumentUpdaterManager.flushProjectToMongoAndDelete project_id, (err) ->

--- a/app/coffee/WebsocketLoadBalancer.coffee
+++ b/app/coffee/WebsocketLoadBalancer.coffee
@@ -71,7 +71,7 @@ module.exports = WebsocketLoadBalancer =
 					if err?
 						return logger.err {room: message.room_id, err}, "failed to get room clients"
 					logger.log {channel:channel, message: message.message, room_id: message.room_id, message_id: message._id, socketIoClients: clientIds}, "refreshing client list"
-					for clientId in clientIds when io.sockets.connected[clientId] # filter disconnected clients
+					for clientId in clientIds
 						ConnectedUsersManager.refreshClient(message.room_id, clientId)
 			else if message.room_id?
 				if message._id? && Settings.checkEventOrder
@@ -86,7 +86,6 @@ module.exports = WebsocketLoadBalancer =
 
 					clientList = clientIds
 					.map((id) -> io.sockets.connected[id])
-					.filter(Boolean) # filter disconnected clients
 					.filter((client) ->
 						!(is_restricted_message && client.ol_context['is_restricted_user'])
 					)

--- a/app/coffee/WebsocketLoadBalancer.coffee
+++ b/app/coffee/WebsocketLoadBalancer.coffee
@@ -67,7 +67,7 @@ module.exports = WebsocketLoadBalancer =
 			if message.room_id == "all"
 				io.sockets.emit(message.message, message.payload...)
 			else if message.message is 'clientTracking.refresh' && message.room_id?
-				io.to(message.room_id).clients (err, clientIds) ->
+				RoomManager.getClientsInRoomPseudoAsync io, message.room_id, (err, clientIds) ->
 					if err?
 						return logger.err {room: message.room_id, err}, "failed to get room clients"
 					logger.log {channel:channel, message: message.message, room_id: message.room_id, message_id: message._id, socketIoClients: clientIds}, "refreshing client list"
@@ -78,7 +78,7 @@ module.exports = WebsocketLoadBalancer =
 					status = EventLogger.checkEventOrder("editor-events", message._id, message)
 					if status is "duplicate"
 						return # skip duplicate events
-				io.to(message.room_id).clients (err, clientIds) ->
+				RoomManager.getClientsInRoomPseudoAsync io, message.room_id, (err, clientIds) ->
 					if err?
 						return logger.err {room: message.room_id, err}, "failed to get room clients"
 

--- a/test/unit/coffee/DocumentUpdaterControllerTests.coffee
+++ b/test/unit/coffee/DocumentUpdaterControllerTests.coffee
@@ -41,7 +41,7 @@ describe "DocumentUpdaterController", ->
 			@rclient[1].subscribe = sinon.stub()
 			@rclient[1].on = sinon.stub()
 			@EditorUpdatesController.listenForUpdatesFromDocumentUpdater()
-		
+
 		it "should subscribe to the doc-updater stream", ->
 			@rclient[0].subscribe.calledWith("applied-ops").should.equal true
 
@@ -57,7 +57,7 @@ describe "DocumentUpdaterController", ->
 			beforeEach ->
 				@SafeJsonParse.parse = sinon.stub().callsArgWith 1, new Error("oops")
 				@EditorUpdatesController._processMessageFromDocumentUpdater @io, "applied-ops", "blah"
-			
+
 			it "should log an error", ->
 				@logger.error.called.should.equal true
 
@@ -137,7 +137,7 @@ describe "DocumentUpdaterController", ->
 			beforeEach ->
 				@update.dup = true
 				@EditorUpdatesController._applyUpdateFromDocumentUpdater @io, @doc_id, @update
-			
+
 			it "should send a version bump to the source client as usual", ->
 				@sourceClient.emit
 					.calledWith("otUpdateApplied", v: @version, doc: @doc_id)
@@ -158,14 +158,16 @@ describe "DocumentUpdaterController", ->
 			client_mapping[@clients[0].id] = @clients[0]
 			client_mapping[@clients[1].id] = @clients[1]
 			@io.sockets = {connected: client_mapping}
-			@io.to = sinon.stub().returns(clients: sinon.stub().yields(null, [@clients[0].id, @clients[1].id]))
+			@RoomManager.getClientsInRoomPseudoAsync = sinon.stub().yields(null, [@clients[0].id, @clients[1].id])
 			@EditorUpdatesController._processErrorFromDocumentUpdater @io, @doc_id, "Something went wrong"
 
 		it "should log a warning", ->
 			@logger.warn.called.should.equal true
 
 		it "should disconnect all clients in that document", ->
-			@io.to.calledWith(@doc_id).should.equal true
+			@RoomManager.getClientsInRoomPseudoAsync
+				.calledWith(@io, @doc_id)
+				.should.equal true
 			for client in @clients
 				client.disconnect.called.should.equal true
 

--- a/test/unit/coffee/WebsocketControllerTests.coffee
+++ b/test/unit/coffee/WebsocketControllerTests.coffee
@@ -119,11 +119,7 @@ describe 'WebsocketController', ->
 			@WebsocketLoadBalancer.emitToRoom = sinon.stub()
 			@RoomManager.leaveProjectAndDocs = sinon.stub()
 			@clientsInRoom = []
-			@io =
-				in: (room_id) =>
-					if room_id != @project_id
-						throw "expected room_id to be project_id"
-					{clients: (cb) => cb null, @clientsInRoom}
+			@RoomManager.getClientsInRoomPseudoAsync = sinon.stub().yields(null, @clientsInRoom)
 			@client.ol_context.project_id = @project_id
 			@client.ol_context.user_id = @user_id
 			@WebsocketController.FLUSH_IF_EMPTY_DELAY = 0
@@ -131,7 +127,6 @@ describe 'WebsocketController', ->
 
 		describe "when the project is empty", ->
 			beforeEach (done) ->
-				@clientsInRoom = []
 				@WebsocketController.leaveProject @io, @client, done
 
 			it "should end clientTracking.clientDisconnected to the project room", ->
@@ -159,7 +154,7 @@ describe 'WebsocketController', ->
 
 		describe "when the project is not empty", ->
 			beforeEach ->
-				@clientsInRoom = ["mock-remaining-client"]
+				@clientsInRoom.push("mock-remaining-client")
 				@WebsocketController.leaveProject @io, @client
 
 			it "should not flush the project in the document updater", ->

--- a/test/unit/coffee/WebsocketLoadBalancerTests.coffee
+++ b/test/unit/coffee/WebsocketLoadBalancerTests.coffee
@@ -83,8 +83,8 @@ describe "WebsocketLoadBalancer", ->
 					'client-id-1': {id: 'client-id-1', emit: @emit1 = sinon.stub(), ol_context: {}}
 					'client-id-2': {id: 'client-id-2', emit: @emit2 = sinon.stub(), ol_context: {}}
 				}
-				@io.to = sinon.stub().returns(
-					clients: sinon.stub().yields(null, ['client-id-1', 'client-id-2'])
+				@RoomManager.getClientsInRoomPseudoAsync = sinon.stub().yields(
+					null, ['client-id-1', 'client-id-2']
 				)
 				data = JSON.stringify
 					room_id: @room_id
@@ -93,8 +93,8 @@ describe "WebsocketLoadBalancer", ->
 				@WebsocketLoadBalancer._processEditorEvent(@io, "editor-events", data)
 
 			it "should send the message to all (unique) clients in the room", ->
-				@io.to
-					.calledWith(@room_id)
+				@RoomManager.getClientsInRoomPseudoAsync
+					.calledWith(@io, @room_id)
 					.should.equal true
 				@emit1.calledWith(@message, @payload...).should.equal true
 				@emit2.calledWith(@message, @payload...).should.equal true
@@ -106,8 +106,8 @@ describe "WebsocketLoadBalancer", ->
 					'client-id-2': {id: 'client-id-2', emit: @emit2 = sinon.stub(), ol_context: {}}
 					'client-id-4': {id: 'client-id-4', emit: @emit4 = sinon.stub(), ol_context: {is_restricted_user: true}}
 				}
-				@io.to = sinon.stub().returns(
-					clients: sinon.stub().yields(null, ['client-id-1', 'client-id-2', 'client-id-4'])
+				@RoomManager.getClientsInRoomPseudoAsync = sinon.stub().yields(
+					null, ['client-id-1', 'client-id-2', 'client-id-4']
 				)
 				data = JSON.stringify
 					room_id: @room_id
@@ -116,8 +116,8 @@ describe "WebsocketLoadBalancer", ->
 				@WebsocketLoadBalancer._processEditorEvent(@io, "editor-events", data)
 
 			it "should send the message to all (unique) clients in the room", ->
-				@io.to
-					.calledWith(@room_id)
+				@RoomManager.getClientsInRoomPseudoAsync
+					.calledWith(@io, @room_id)
 					.should.equal true
 				@emit1.calledWith(@message, @payload...).should.equal true
 				@emit2.calledWith(@message, @payload...).should.equal true
@@ -130,8 +130,8 @@ describe "WebsocketLoadBalancer", ->
 					'client-id-2': {id: 'client-id-2', emit: @emit2 = sinon.stub(), ol_context: {}}
 					'client-id-4': {id: 'client-id-4', emit: @emit4 = sinon.stub(), ol_context: {is_restricted_user: true}}
 				}
-				@io.to = sinon.stub().returns(
-					clients: sinon.stub().yields(null, ['client-id-1', 'client-id-2', 'client-id-4'])
+				@RoomManager.getClientsInRoomPseudoAsync = sinon.stub().yields(
+					null, ['client-id-1', 'client-id-2', 'client-id-4']
 				)
 				data = JSON.stringify
 					room_id: @room_id
@@ -140,8 +140,8 @@ describe "WebsocketLoadBalancer", ->
 				@WebsocketLoadBalancer._processEditorEvent(@io, "editor-events", data)
 
 			it "should send the message to all (unique) clients in the room, who are not restricted", ->
-				@io.to
-					.calledWith(@room_id)
+				@RoomManager.getClientsInRoomPseudoAsync
+					.calledWith(@io, @room_id)
 					.should.equal true
 				@emit1.calledWith(@restrictedMessage, @payload...).should.equal true
 				@emit2.calledWith(@restrictedMessage, @payload...).should.equal true


### PR DESCRIPTION
### Description

Implement https://digital-science.slack.com/archives/G6256GXGS/p1587995985009900?thread_ts=1587995558.008500&cid=G6256GXGS

Getting a client list and processing the contents of it is now safe -- the clients in the list are all connected and there are no other clients that may joined/left the room as we process the list.

This fixes the race condition in socket.io-adapter of calculating the room list and returning the list via `process.nextTick`.
https://github.com/socketio/socket.io-adapter/blob/ae23c7ef4cd1b1793121b5af0376686a2ba2deea/index.js#L210

Given that we check the connected state of all clients in the new helper `RoomManager.getClientsInRoomSync` it is safe to revert #127 .

#### Related Issues / PRs

#127 

### Review

The unit tests are probably useless when upgrading socket.io, but I added them anyways.


#### Potential Impact

High. `getClientsInRoomSync` is deciding who can see which message.


#### Manual Testing Performed

- acceptance tests were extended as part of the socket.io v2 upgrade -- including cross project message leak checks: https://github.com/overleaf/real-time/pull/107

