### PR TITLE
[misc] get the list of rooms a client is in in a synchronous fashion

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,3 @@
 [app/coffee/RoomManager.coffee]
 indent_style = space
+indent_size = 4

--- a/app/coffee/RoomManager.coffee
+++ b/app/coffee/RoomManager.coffee
@@ -122,7 +122,5 @@ module.exports = RoomManager =
         #  cycle. We would not pick up the room (we just joined) for leaving.
         roomRegistry = client.server.sockets.adapter.sids
         return [] unless roomRegistry.hasOwnProperty(client.id)
-        rooms = Object.keys(roomRegistry[client.id])
-        # skip the socket id
-        rooms.splice(rooms.indexOf(client.id), 1)
+        rooms = (room for room in Object.keys(roomRegistry[client.id]) when room isnt client.id)  # exclude the client socket entry
         return rooms

--- a/app/coffee/RoomManager.coffee
+++ b/app/coffee/RoomManager.coffee
@@ -90,11 +90,10 @@ module.exports = RoomManager =
         cb(@getClientsInRoomSync(client.server, room).length)
 
     _roomsClientIsIn: (client) ->
-        # skip the socket id
-        return Object.keys(client.rooms).slice(1)
+        return @getRoomsClientIsInSync(client)
 
     _clientAlreadyInRoom: (client, room) ->
-        return client.rooms.hasOwnProperty(room)
+        return @getRoomsClientIsInSync(client).indexOf(room) != -1
 
     getClientsInRoomSync: (io, room) ->
         # the implementation in socket.io-adapter is prone to race conditions:
@@ -113,3 +112,17 @@ module.exports = RoomManager =
     # calling it asynchronously would lead to race conditions -- see above
     getClientsInRoomPseudoAsync: (io, room, cb) ->
         cb(null, RoomManager.getClientsInRoomSync(io, room))
+
+    getRoomsClientIsInSync: (client) ->
+        # The implementation in socket.io is prone to race conditions:
+        # The adapter will get updated immediately from joining, but the
+        #  client local state (.rooms) is updated via process.nextTick.
+        # Given that NodeJS can process multiple network events in the same
+        #  event loop cycle, we can join a project and disconnect in the same
+        #  cycle. We would not pick up the room (we just joined) for leaving.
+        roomRegistry = client.server.sockets.adapter.sids
+        return [] unless roomRegistry.hasOwnProperty(client.id)
+        rooms = Object.keys(roomRegistry[client.id])
+        # skip the socket id
+        rooms.splice(rooms.indexOf(client.id), 1)
+        return rooms


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Followup for #128 

`client.rooms` is not safe to use.

<details>
the implementation in socket.io is prone to race conditions:
The adapter will get updated immediately from joining, but the client
 local state (.rooms) is updated via process.nextTick.
Given that NodeJS can process multiple network events in the same event
 loop cycle, we can join a project and disconnect in the same cycle.
We will not pick up the room (we just joined) for leaving.
</details>

#### Related Issues / PRs

#128 

#### Potential Impact

Low.

