### PR TITLE
[misc] clear on subscribe failure

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,7 @@
+[app/coffee/ChannelManager.coffee]
+indent_style = space
+indent_size = 4
+
 [app/coffee/RoomManager.coffee]
 indent_style = space
 indent_size = 4

--- a/app/coffee/ChannelManager.coffee
+++ b/app/coffee/ChannelManager.coffee
@@ -31,13 +31,11 @@ module.exports = ChannelManager =
             clientChannelMap.set(channel, subscribePromise)
             logger.log {channel}, "subscribed to new channel"
             metrics.inc "subscribe.#{baseChannel}"
-            return new Promise (resolve, reject) ->
-                subscribePromise.then(resolve)
-                subscribePromise.catch (err) ->
-                    metrics.inc "subscribe.failed.#{baseChannel}"
-                    # clear state
-                    clientChannelMap.delete(channel)
-                    reject(err)
+            subscribePromise.catch () ->
+                metrics.inc "subscribe.failed.#{baseChannel}"
+                # clear state
+                clientChannelMap.delete(channel)
+            return subscribePromise
 
     unsubscribe: (rclient, baseChannel, id) ->
         clientChannelMap = @getClientMapEntry(rclient)

--- a/app/coffee/ChannelManager.coffee
+++ b/app/coffee/ChannelManager.coffee
@@ -31,7 +31,13 @@ module.exports = ChannelManager =
             clientChannelMap.set(channel, subscribePromise)
             logger.log {channel}, "subscribed to new channel"
             metrics.inc "subscribe.#{baseChannel}"
-            return subscribePromise
+            return new Promise (resolve, reject) ->
+                subscribePromise.then(resolve)
+                subscribePromise.catch (err) ->
+                    metrics.inc "subscribe.failed.#{baseChannel}"
+                    # clear state
+                    clientChannelMap.delete(channel)
+                    reject(err)
 
     unsubscribe: (rclient, baseChannel, id) ->
         clientChannelMap = @getClientMapEntry(rclient)

--- a/package-lock.json
+++ b/package-lock.json
@@ -716,15 +716,6 @@
         "type-detect": "0.1.1"
       }
     },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
-      "dev": true,
-      "requires": {
-        "object-keys": "^1.0.12"
-      }
-    },
     "delay": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/delay/-/delay-4.3.0.tgz",
@@ -749,6 +740,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
     },
     "dtrace-provider": {
       "version": "0.2.8",
@@ -901,31 +898,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
-    },
-    "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha1-rIYUX91QmdjdSVWMy6Lq+biOJOk=",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "^1.2.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
     },
     "es6-promise": {
       "version": "4.2.8",
@@ -1182,12 +1154,12 @@
       }
     },
     "formatio": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
-      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
       "dev": true,
       "requires": {
-        "samsam": "~1.1"
+        "samsam": "1.x"
       }
     },
     "forwarded": {
@@ -1204,12 +1176,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
     "gaxios": {
@@ -1325,15 +1291,6 @@
         "har-schema": "^2.0.0"
       }
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "has-binary2": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
@@ -1353,12 +1310,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
-    },
-    "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
-      "dev": true
     },
     "he": {
       "version": "1.1.1",
@@ -1484,52 +1435,10 @@
       "resolved": "https://registry.npmjs.org/is/-/is-3.3.0.tgz",
       "integrity": "sha512-nW24QBoPcFGGHJGUwnfpI7Yc5CdqWNdsyHQszVE/z2pKHXzh7FZ5GWhJqSyaQ9wMkQnsTx+kAI8bHlCX4tKdbg=="
     },
-    "is-arguments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha1-P6+WbHy6D/Q3+zH2JQCC/PBEjPM=",
-      "dev": true
-    },
     "is-buffer": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
       "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-    },
-    "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
-      "dev": true
-    },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
-    },
-    "is-generator-function": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
-      "integrity": "sha1-0hMuUpuwAAp/gHlNS99c1eWBNSI=",
-      "dev": true
-    },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.1"
-      }
-    },
-    "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.0"
-      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1664,9 +1573,9 @@
       }
     },
     "lolex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+      "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
       "dev": true
     },
     "long": {
@@ -1891,6 +1800,12 @@
       "integrity": "sha1-OSHhECMtHreQ89rGG7NwUxx9NW4=",
       "dev": true
     },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+      "dev": true
+    },
     "ncp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
@@ -1921,24 +1836,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
-    },
-    "object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
-      "dev": true
-    },
-    "object.entries": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-      "integrity": "sha1-ICT8bWuiRq7ji9sP/Vz7zzcbdRk=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3"
-      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -2374,9 +2271,9 @@
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
     },
     "samsam": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
     },
     "sandboxed-module": {
@@ -2471,15 +2368,42 @@
       "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "sinon": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
-      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+      "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
       "dev": true,
       "requires": {
-        "formatio": "1.1.1",
-        "lolex": "1.3.2",
-        "samsam": "1.1.2",
-        "util": ">=0.10.3 <1"
+        "diff": "^3.1.0",
+        "formatio": "1.2.0",
+        "lolex": "^1.6.0",
+        "native-promise-only": "^0.8.1",
+        "path-to-regexp": "^1.7.0",
+        "samsam": "^1.1.3",
+        "text-encoding": "0.6.4",
+        "type-detect": "^4.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        },
+        "type-detect": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+          "dev": true
+        }
       }
     },
     "socket.io": {
@@ -2766,6 +2690,12 @@
         }
       }
     },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -2862,27 +2792,6 @@
         }
       }
     },
-    "util": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.1.tgz",
-      "integrity": "sha1-+QjntjPnOWx2TmlN0U5xYlbOit4=",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "object.entries": "^1.1.0",
-        "safe-buffer": "^5.1.2"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-          "integrity": "sha1-t02uxJsRSPiMZLaNSbHoFcHy9Rk=",
-          "dev": true
-        }
-      }
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2935,15 +2844,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
-    "yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
-    },
     "yeast": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "chai": "~1.9.1",
     "cookie-signature": "^1.0.5",
     "sandboxed-module": "~0.3.0",
-    "sinon": "^1.5.2",
+    "sinon": "^2.4.1",
     "mocha": "^4.0.1",
     "uid-safe": "^1.0.1",
     "timekeeper": "0.0.4"

--- a/test/unit/coffee/AuthorizationManagerTests.coffee
+++ b/test/unit/coffee/AuthorizationManagerTests.coffee
@@ -19,19 +19,19 @@ describe 'AuthorizationManager', ->
 			@AuthorizationManager.assertClientCanViewProject @client, (error) ->
 				expect(error).to.be.null
 				done()
-	
+
 		it "should allow the readAndWrite privilegeLevel", (done) ->
 			@client.ol_context.privilege_level = "readAndWrite"
 			@AuthorizationManager.assertClientCanViewProject @client, (error) ->
 				expect(error).to.be.null
 				done()
-				
+
 		it "should allow the owner privilegeLevel", (done) ->
 			@client.ol_context.privilege_level = "owner"
 			@AuthorizationManager.assertClientCanViewProject @client, (error) ->
 				expect(error).to.be.null
 				done()
-				
+
 		it "should return an error with any other privilegeLevel", (done) ->
 			@client.ol_context.privilege_level = "unknown"
 			@AuthorizationManager.assertClientCanViewProject @client, (error) ->
@@ -44,19 +44,19 @@ describe 'AuthorizationManager', ->
 			@AuthorizationManager.assertClientCanEditProject @client, (error) ->
 				error.message.should.equal "not authorized"
 				done()
-	
+
 		it "should allow the readAndWrite privilegeLevel", (done) ->
 			@client.ol_context.privilege_level = "readAndWrite"
 			@AuthorizationManager.assertClientCanEditProject @client, (error) ->
 				expect(error).to.be.null
 				done()
-				
+
 		it "should allow the owner privilegeLevel", (done) ->
 			@client.ol_context.privilege_level = "owner"
 			@AuthorizationManager.assertClientCanEditProject @client, (error) ->
 				expect(error).to.be.null
 				done()
-				
+
 		it "should return an error with any other privilegeLevel", (done) ->
 			@client.ol_context.privilege_level = "unknown"
 			@AuthorizationManager.assertClientCanEditProject @client, (error) ->
@@ -76,20 +76,16 @@ describe 'AuthorizationManager', ->
 				@client.ol_context.privilege_level = "unknown"
 
 			it "should not allow access", () ->
-				@AuthorizationManager.assertClientCanViewProjectAndDoc @client, @doc_id, @callback
-				@callback
-					.calledWith(new Error("not authorised"))
-					.should.equal true
+				@AuthorizationManager.assertClientCanViewProjectAndDoc @client, @doc_id, (err) ->
+					err.message.should.equal "not authorized"
 
 			describe "even when authorised at the doc level", ->
 				beforeEach (done) ->
 					@AuthorizationManager.addAccessToDoc @client, @doc_id, done
 
 				it "should not allow access", () ->
-					@AuthorizationManager.assertClientCanViewProjectAndDoc @client, @doc_id, @callback
-					@callback
-						.calledWith(new Error("not authorised"))
-						.should.equal true
+					@AuthorizationManager.assertClientCanViewProjectAndDoc @client, @doc_id, (err) ->
+						err.message.should.equal "not authorized"
 
 		describe "when authorised at the project level", ->
 			beforeEach () ->
@@ -97,10 +93,8 @@ describe 'AuthorizationManager', ->
 
 			describe "and not authorised at the document level", ->
 				it "should not allow access", () ->
-					@AuthorizationManager.assertClientCanViewProjectAndDoc @client, @doc_id, @callback
-					@callback
-						.calledWith(new Error("not authorised"))
-						.should.equal true
+					@AuthorizationManager.assertClientCanViewProjectAndDoc @client, @doc_id, (err) ->
+						err.message.should.equal "not authorized"
 
 			describe "and authorised at the document level", ->
 				beforeEach (done) ->
@@ -118,10 +112,8 @@ describe 'AuthorizationManager', ->
 						@AuthorizationManager.removeAccessToDoc @client, @doc_id, done
 
 				it "should deny access", () ->
-					@AuthorizationManager.assertClientCanViewProjectAndDoc @client, @doc_id, @callback
-					@callback
-						.calledWith(new Error("not authorised"))
-						.should.equal true
+					@AuthorizationManager.assertClientCanViewProjectAndDoc @client, @doc_id, (err) ->
+						err.message.should.equal "not authorized"
 
 	describe "assertClientCanEditProjectAndDoc", ->
 		beforeEach () ->
@@ -134,20 +126,16 @@ describe 'AuthorizationManager', ->
 				@client.ol_context.privilege_level = "readOnly"
 
 			it "should not allow access", () ->
-				@AuthorizationManager.assertClientCanEditProjectAndDoc @client, @doc_id, @callback
-				@callback
-					.calledWith(new Error("not authorised"))
-					.should.equal true
+				@AuthorizationManager.assertClientCanEditProjectAndDoc @client, @doc_id, (err) ->
+					err.message.should.equal "not authorized"
 
 			describe "even when authorised at the doc level", ->
 				beforeEach (done) ->
 					@AuthorizationManager.addAccessToDoc @client, @doc_id, done
 
 				it "should not allow access", () ->
-					@AuthorizationManager.assertClientCanEditProjectAndDoc @client, @doc_id, @callback
-					@callback
-						.calledWith(new Error("not authorised"))
-						.should.equal true
+					@AuthorizationManager.assertClientCanEditProjectAndDoc @client, @doc_id, (err) ->
+						err.message.should.equal "not authorized"
 
 		describe "when authorised at the project level", ->
 			beforeEach () ->
@@ -155,10 +143,8 @@ describe 'AuthorizationManager', ->
 
 			describe "and not authorised at the document level", ->
 				it "should not allow access", () ->
-					@AuthorizationManager.assertClientCanEditProjectAndDoc @client, @doc_id, @callback
-					@callback
-						.calledWith(new Error("not authorised"))
-						.should.equal true
+					@AuthorizationManager.assertClientCanEditProjectAndDoc @client, @doc_id, (err) ->
+						err.message.should.equal "not authorized"
 
 			describe "and authorised at the document level", ->
 				beforeEach (done) ->
@@ -176,7 +162,5 @@ describe 'AuthorizationManager', ->
 						@AuthorizationManager.removeAccessToDoc @client, @doc_id, done
 
 				it "should deny access", () ->
-					@AuthorizationManager.assertClientCanEditProjectAndDoc @client, @doc_id, @callback
-					@callback
-						.calledWith(new Error("not authorised"))
-						.should.equal true
+					@AuthorizationManager.assertClientCanEditProjectAndDoc @client, @doc_id, (err) ->
+						err.message.should.equal "not authorized"

--- a/test/unit/coffee/ChannelManagerTests.coffee
+++ b/test/unit/coffee/ChannelManagerTests.coffee
@@ -12,12 +12,12 @@ describe 'ChannelManager', ->
 			"settings-sharelatex": @settings = {}
 			"metrics-sharelatex": @metrics = {inc: sinon.stub(), summary: sinon.stub()}
 			"logger-sharelatex": @logger = { log: sinon.stub(), warn: sinon.stub(), error: sinon.stub() }
-	
+
 	describe "subscribe", ->
 
 		describe "when there is no existing subscription for this redis client", ->
 			beforeEach ->
-				@rclient.subscribe = sinon.stub()
+				@rclient.subscribe = sinon.stub().resolves()
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
 
 			it "should subscribe to the redis channel", ->
@@ -25,19 +25,40 @@ describe 'ChannelManager', ->
 
 		describe "when there is an existing subscription for this redis client", ->
 			beforeEach ->
-				@rclient.subscribe = sinon.stub()
+				@rclient.subscribe = sinon.stub().resolves()
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
-				@rclient.subscribe = sinon.stub()  # discard the original stub
+				@rclient.subscribe = sinon.stub().resolves()  # discard the original stub
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
 
 			it "should not subscribe to the redis channel", ->
 				@rclient.subscribe.called.should.equal false
 
+		describe "when subscribe errors", ->
+			# TODO(das7pad): rework after decaff -- our coffee-script version does not like async/await
+			beforeEach (done) ->
+				@rclient.subscribe = () ->
+					return new Promise (resolve, reject) ->
+						setTimeout((() -> reject(new Error("some redis error"))), 1)
+				p = @ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
+				@rclient.subscribe = sinon.stub().resolves()
+				p.then () ->
+					done(new Error('should not subscribe but fail'))
+				p.catch (err) =>
+					err.message.should.equal "some redis error"
+					@ChannelManager.getClientMapEntry(@rclient).has("applied-ops:1234567890abcdef").should.equal false
+					@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
+					done()
+				return null
+
+			it "should subscribe again", ->
+				@rclient.subscribe.called.should.equal true
+				@ChannelManager.getClientMapEntry(@rclient).has("applied-ops:1234567890abcdef").should.equal true
+
 		describe "when there is an existing subscription for another redis client but not this one", ->
 			beforeEach ->
-				@other_rclient.subscribe = sinon.stub()
+				@other_rclient.subscribe = sinon.stub().resolves()
 				@ChannelManager.subscribe @other_rclient, "applied-ops", "1234567890abcdef"
-				@rclient.subscribe = sinon.stub()  # discard the original stub
+				@rclient.subscribe = sinon.stub().resolves()  # discard the original stub
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
 
 			it "should subscribe to the redis channel on this redis client", ->
@@ -56,8 +77,8 @@ describe 'ChannelManager', ->
 
 		describe "when there is an existing subscription for this another redis client but not this one", ->
 			beforeEach ->
-				@other_rclient.subscribe = sinon.stub()
-				@rclient.unsubscribe = sinon.stub()  
+				@other_rclient.subscribe = sinon.stub().resolves()
+				@rclient.unsubscribe = sinon.stub()
 				@ChannelManager.subscribe @other_rclient, "applied-ops", "1234567890abcdef"
 				@ChannelManager.unsubscribe @rclient, "applied-ops", "1234567890abcdef"
 
@@ -66,8 +87,8 @@ describe 'ChannelManager', ->
 
 		describe "when there is an existing subscription for this redis client", ->
 			beforeEach ->
-				@rclient.subscribe = sinon.stub()
-				@rclient.unsubscribe = sinon.stub()  
+				@rclient.subscribe = sinon.stub().resolves()
+				@rclient.unsubscribe = sinon.stub()
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
 				@ChannelManager.unsubscribe @rclient, "applied-ops", "1234567890abcdef"
 

--- a/test/unit/coffee/WebApiManagerTests.coffee
+++ b/test/unit/coffee/WebApiManagerTests.coffee
@@ -60,7 +60,7 @@ describe 'WebApiManager', ->
 
 			it "should call the callback with an error", ->
 				@callback
-					.calledWith(new Error("non-success code from web: 500"))
+					.calledWith(sinon.match({message: "non-success status code from web: 500"}))
 					.should.equal true
 
 		describe "with no data from web", ->
@@ -70,7 +70,7 @@ describe 'WebApiManager', ->
 
 			it "should call the callback with an error", ->
 				@callback
-					.calledWith(new Error("no data returned from joinProject request"))
+					.calledWith(sinon.match({message: "no data returned from joinProject request"}))
 					.should.equal true
 
 		describe "when the project is over its rate limit", ->
@@ -80,5 +80,5 @@ describe 'WebApiManager', ->
 
 			it "should call the callback with a TooManyRequests error code", ->
 				@callback
-					.calledWith(new CodedError("rate-limit hit when joining project", "TooManyRequests"))
+					.calledWith(sinon.match({message: "rate-limit hit when joining project", code: "TooManyRequests"}))
 					.should.equal true

--- a/test/unit/coffee/WebsocketControllerTests.coffee
+++ b/test/unit/coffee/WebsocketControllerTests.coffee
@@ -106,7 +106,7 @@ describe 'WebsocketController', ->
 
 			it "should return an error", ->
 				@callback
-					.calledWith(new Error("not authorized"))
+					.calledWith(sinon.match({message: "not authorized"}))
 					.should.equal true
 
 			it "should not log an error", ->
@@ -315,7 +315,7 @@ describe 'WebsocketController', ->
 				@WebsocketController.joinDoc @client, @doc_id, -1, @options, @callback
 
 			it "should call the callback with an error", ->
-				@callback.calledWith(@err).should.equal true
+				@callback.calledWith(sinon.match({message: "not authorized"})).should.equal true
 
 			it "should not call the DocumentUpdaterManager", ->
 				@DocumentUpdaterManager.getDocument.called.should.equal false


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

For https://github.com/overleaf/issues/issues/3002

Upon detecting a redis pub/sub subscribe failure we should discard the 'subscribed' state for the entity and let the next request start from scratch.

Currently based onto #129 

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3002


### Review

`sinon` < 2 does not support promises. So I went the long way of upgrading it for proper stub support https://github.com/overleaf/real-time/commit/3c92b937f9430175d7c51660e03c507635448e88. This required some fixes to the way we check error messages -- in fact sinon did not check the error message and lots of tests failed after the upgrade https://github.com/overleaf/real-time/commit/d9570fee70701a5f431c39fdbec5f8bc5a7843fe.

I could not get the unhandled promise rejection warning in the unit tests to disappear, even tho I added a `catch` handler. Presumably with the decaff process we can rewrite this into an `async` function (which is technically supported by coffee-script, but not in our ancient version). I left a TODO line for that.

#### Potential Impact

Low. Subscribing to a redis channel twice is considered safe.

#### Metrics and Monitoring

New metric `subscribe.failed.#{baseChannel}` (base channel is `applied-ops` or `editor-events`)
