### PR TITLE
[misc] restore the default pingTimeout of 60s from socket.io v0

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -30,7 +30,10 @@ server = require('http').createServer(app)
 io = require('socket.io')(server, {
 	path: Settings.socketIoPath,
 	cookie: false,
-	origins: Settings.socketIoOrigins
+	origins: Settings.socketIoOrigins,
+
+	# restore v0 default
+	pingTimeout: 60 * 1000,
 })
 
 # Bind to sessions


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

https://digital-science.slack.com/archives/G6256GXGS/p1588666706113600

> The heartbeat timeout for socket.io changed from v0 (60s) to v2 (5s). Given that the browser is not putting the tab into full sleep, but just makes it slow, we could just bump that timeout back up.
>
> v0: https://github.com/socketio/socket.io/blob/41b9a7e45d62ead3b4b36dc38cc8c03882ecc577/lib/manager.js#L78
> v2: https://github.com/socketio/engine.io/blob/dcdbccb3dd8a7b7db057d23925356034fcd35d48/lib/server.js#L26 

> In case the connection is bad the user will eventually get an out-out-sync error (with 100 ops in between their update and others, that's really slow then) or it will just work fine.

#### Screenshots

v0 handshake:
https://github.com/socketio/socket.io/blob/41b9a7e45d62ead3b4b36dc38cc8c03882ecc577/lib/manager.js#L808
```
SOME_ID:60:60:websocket,flashsocket,htmlfile,xhr-polling,jsonp-polling`
        ^ ping timeout
``` 

v2 before this PR
```
96:0{"sid":"SOME_ID","upgrades":["websocket"],"pingInterval":25000,"pingTimeout":5000}2:40
```
v2 with this patch
```
97:0{"sid":"SOME_ID","upgrades":["websocket"],"pingInterval":25000,"pingTimeout":60000}2:40
```

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3003

#### Potential Impact

Low. Affects slow connections only.

#### Manual Testing Performed

- open editor in dev-env

