### PR TITLE
[ChannelManager] cleanup from redis subscribe error more carefully

### DIFF
--- a/app/coffee/ChannelManager.coffee
+++ b/app/coffee/ChannelManager.coffee
@@ -33,8 +33,10 @@ module.exports = ChannelManager =
             metrics.inc "subscribe.#{baseChannel}"
             subscribePromise.catch () ->
                 metrics.inc "subscribe.failed.#{baseChannel}"
-                # clear state
-                clientChannelMap.delete(channel)
+                # clear state on error, following subscribes should retry
+                # new subscribe requests can overtake, skip cleanup then
+                if clientChannelMap.get(channel) is subscribePromise
+                    clientChannelMap.delete(channel)
             return subscribePromise
 
     unsubscribe: (rclient, baseChannel, id) ->

--- a/test/unit/coffee/ChannelManagerTests.coffee
+++ b/test/unit/coffee/ChannelManagerTests.coffee
@@ -34,7 +34,6 @@ describe 'ChannelManager', ->
 				@rclient.subscribe.called.should.equal false
 
 		describe "when subscribe errors", ->
-			# TODO(das7pad): rework after decaff -- our coffee-script version does not like async/await
 			beforeEach (done) ->
 				@rclient.subscribe = () ->
 					return new Promise (resolve, reject) ->
@@ -43,7 +42,7 @@ describe 'ChannelManager', ->
 				@rclient.subscribe = sinon.stub().resolves()
 				p.then () ->
 					done(new Error('should not subscribe but fail'))
-				p.catch (err) =>
+				.catch (err) =>
 					err.message.should.equal "some redis error"
 					@ChannelManager.getClientMapEntry(@rclient).has("applied-ops:1234567890abcdef").should.equal false
 					@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"


### PR DESCRIPTION
### Description

There is a minor race condition with the redis pub/sub subscribe cleanup on error:

Take this sequence: subscribe -> unsubscribe -> subscribe

The unsubscribe clears the subscribe map and the second subscribe will
 insert its promise into the map. We should not cleanup the subscribe
 promise when the first subscribe errors.

Without this patch, we are doing another subscribe request for a 3rd subscribe call.

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3002


### Review

I added another commit to suppress the unhandledRejection warnings -- we do handle them, but from a sync function and moving to async functions will magically get rid of them when we are there.

#### Potential Impact

Low. Code path is reachable from failing subscribes, which should not happen.


#### Manual Testing Performed

- added unit test

