### PR TITLE
[ChannelManager] enforce a strict sequence of redis (un)subscribes

### DIFF
--- a/test/acceptance/coffee/PubSubRace.coffee
+++ b/test/acceptance/coffee/PubSubRace.coffee
@@ -1,0 +1,212 @@
+RealTimeClient = require "./helpers/RealTimeClient"
+MockDocUpdaterServer = require "./helpers/MockDocUpdaterServer"
+FixturesManager = require "./helpers/FixturesManager"
+{getClientId} = require "./helpers/SocketIoUtils"
+
+async = require "async"
+
+settings = require "settings-sharelatex"
+redis = require "redis-sharelatex"
+rclient = redis.createClient(settings.redis.pubsub)
+
+describe "PubSubRace", ->
+	before (done) ->
+		MockDocUpdaterServer.run done
+
+	describe "when the client leaves a doc before joinDoc completes", ->
+		before (done) ->
+			async.series [
+				(cb) =>
+					FixturesManager.setUpProject {
+						privilegeLevel: "owner"
+						project: {
+							name: "Test Project"
+						}
+					}, (e, {@project_id, @user_id}) => cb()
+
+				(cb) =>
+					@clientA = RealTimeClient.connect()
+					@clientA.on "connect", cb
+
+				(cb) =>
+					@clientA.emit "joinProject", project_id: @project_id, (error, @project, @privilegeLevel, @protocolVersion) =>
+						cb(error)
+
+				(cb) =>
+					FixturesManager.setUpDoc @project_id, {@lines, @version, @ops}, (e, {@doc_id}) =>
+						cb(e)
+
+				(cb) =>
+					@clientA.emit "joinDoc", @doc_id, () ->
+					# leave before joinDoc completes
+					@clientA.emit "leaveDoc", @doc_id, cb
+
+				(cb) =>
+					# wait for subscribe and unsubscribe
+					setTimeout cb, 100
+			], done
+
+		it "should not subscribe to the applied-ops channels anymore", (done) ->
+			rclient.pubsub 'CHANNELS', (err, resp) =>
+				return done(err) if err
+				resp.should.not.include "applied-ops:#{@doc_id}"
+				done()
+			return null
+
+	describe "when the client emits joinDoc and leaveDoc requests frequently and leaves eventually", ->
+		before (done) ->
+			async.series [
+				(cb) =>
+					FixturesManager.setUpProject {
+						privilegeLevel: "owner"
+						project: {
+							name: "Test Project"
+						}
+					}, (e, {@project_id, @user_id}) => cb()
+
+				(cb) =>
+					@clientA = RealTimeClient.connect()
+					@clientA.on "connect", cb
+
+				(cb) =>
+					@clientA.emit "joinProject", project_id: @project_id, (error, @project, @privilegeLevel, @protocolVersion) =>
+						cb(error)
+
+				(cb) =>
+					FixturesManager.setUpDoc @project_id, {@lines, @version, @ops}, (e, {@doc_id}) =>
+						cb(e)
+
+				(cb) =>
+					@clientA.emit "joinDoc", @doc_id, () ->
+					@clientA.emit "leaveDoc", @doc_id, () ->
+					@clientA.emit "joinDoc", @doc_id, () ->
+					@clientA.emit "leaveDoc", @doc_id, () ->
+					@clientA.emit "joinDoc", @doc_id, () ->
+					@clientA.emit "leaveDoc", @doc_id, () ->
+					@clientA.emit "joinDoc", @doc_id, () ->
+					@clientA.emit "leaveDoc", @doc_id, () ->
+					@clientA.emit "joinDoc", @doc_id, () ->
+					@clientA.emit "leaveDoc", @doc_id, cb
+
+				(cb) =>
+					# wait for subscribe and unsubscribe
+					setTimeout cb, 100
+			], done
+
+		it "should have left the doc room", (done) ->
+			RealTimeClient.getConnectedClient getClientId(@clientA), (error, client) =>
+				client.rooms.should.not.include @doc_id
+				done()
+			return null
+
+		it "should not subscribe to the applied-ops channels anymore", (done) ->
+			rclient.pubsub 'CHANNELS', (err, resp) =>
+				return done(err) if err
+				resp.should.not.include "applied-ops:#{@doc_id}"
+				done()
+			return null
+
+	describe "when the client emits joinDoc and leaveDoc requests frequently and remains in the doc", ->
+		before (done) ->
+			async.series [
+				(cb) =>
+					FixturesManager.setUpProject {
+						privilegeLevel: "owner"
+						project: {
+							name: "Test Project"
+						}
+					}, (e, {@project_id, @user_id}) => cb()
+
+				(cb) =>
+					@clientA = RealTimeClient.connect()
+					@clientA.on "connect", cb
+
+				(cb) =>
+					@clientA.emit "joinProject", project_id: @project_id, (error, @project, @privilegeLevel, @protocolVersion) =>
+						cb(error)
+
+				(cb) =>
+					FixturesManager.setUpDoc @project_id, {@lines, @version, @ops}, (e, {@doc_id}) =>
+						cb(e)
+
+				(cb) =>
+					@clientA.emit "joinDoc", @doc_id, () ->
+					@clientA.emit "leaveDoc", @doc_id, () ->
+					@clientA.emit "joinDoc", @doc_id, () ->
+					@clientA.emit "leaveDoc", @doc_id, () ->
+					@clientA.emit "joinDoc", @doc_id, () ->
+					@clientA.emit "leaveDoc", @doc_id, () ->
+					@clientA.emit "joinDoc", @doc_id, () ->
+					@clientA.emit "leaveDoc", @doc_id, () ->
+					@clientA.emit "joinDoc", @doc_id, cb
+
+				(cb) =>
+					# wait for subscribe and unsubscribe
+					setTimeout cb, 100
+			], done
+
+		it "should subscribe to the applied-ops channels", (done) ->
+			rclient.pubsub 'CHANNELS', (err, resp) =>
+				return done(err) if err
+				resp.should.include "applied-ops:#{@doc_id}"
+				done()
+			return null
+
+	describe "when the client disconnects before joinDoc completes", ->
+		before (done) ->
+			async.series [
+				(cb) =>
+					FixturesManager.setUpProject {
+						privilegeLevel: "owner"
+						project: {
+							name: "Test Project"
+						}
+					}, (e, {@project_id, @user_id}) => cb()
+
+				(cb) =>
+					@clientA = RealTimeClient.connect()
+					@clientA.on "connect", cb
+
+				(cb) =>
+					@clientA.emit "joinProject", project_id: @project_id, (error, @project, @privilegeLevel, @protocolVersion) =>
+						cb(error)
+
+				(cb) =>
+					FixturesManager.setUpDoc @project_id, {@lines, @version, @ops}, (e, {@doc_id}) =>
+						cb(e)
+
+				(cb) =>
+					joinDocCompleted = false
+					@clientA.emit "joinDoc", @doc_id, () ->
+						joinDocCompleted = true
+					# leave before joinDoc completes
+					setTimeout () =>
+						if joinDocCompleted
+							return cb(new Error('joinDocCompleted -- lower timeout'))
+						@clientA.on "disconnect", () -> cb()
+						@clientA.disconnect()
+					# socket.io processes joinDoc and disconnect with different delays:
+					#  - joinDoc goes through two process.nextTick
+					#  - disconnect goes through one process.nextTick
+					# We have to inject the disconnect event into a different event loop
+					#  cycle.
+					, 3
+
+				(cb) =>
+					# wait for subscribe and unsubscribe
+					setTimeout cb, 100
+			], done
+
+		it "should not subscribe to the editor-events channels anymore", (done) ->
+			rclient.pubsub 'CHANNELS', (err, resp) =>
+				return done(err) if err
+				resp.should.not.include "editor-events:#{@project_id}"
+				done()
+			return null
+
+		it "should not subscribe to the applied-ops channels anymore", (done) ->
+			rclient.pubsub 'CHANNELS', (err, resp) =>
+				return done(err) if err
+				resp.should.not.include "applied-ops:#{@doc_id}"
+				done()
+			return null

--- a/test/unit/coffee/ChannelManagerTests.coffee
+++ b/test/unit/coffee/ChannelManagerTests.coffee
@@ -17,72 +17,73 @@ describe 'ChannelManager', ->
 	describe "subscribe", ->
 
 		describe "when there is no existing subscription for this redis client", ->
-			beforeEach ->
+			beforeEach (done) ->
 				@rclient.subscribe = sinon.stub().resolves()
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
+				setTimeout done
 
 			it "should subscribe to the redis channel", ->
 				@rclient.subscribe.calledWithExactly("applied-ops:1234567890abcdef").should.equal true
 
 		describe "when there is an existing subscription for this redis client", ->
-			beforeEach ->
+			beforeEach (done) ->
 				@rclient.subscribe = sinon.stub().resolves()
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
-				@rclient.subscribe = sinon.stub().resolves()  # discard the original stub
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
+				setTimeout done
 
 			it "should not subscribe to the redis channel", ->
-				@rclient.subscribe.called.should.equal false
+				@rclient.subscribe.callCount.should.equal 1
 
 		describe "when subscribe errors", ->
 			beforeEach (done) ->
-				@rclient.subscribe = () ->
-					return new Promise (resolve, reject) ->
-						setTimeout((() -> reject(new Error("some redis error"))), 1)
+				@rclient.subscribe = sinon.stub()
+					.onFirstCall().rejects(new Error("some redis error"))
+					.onSecondCall().resolves()
 				p = @ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
-				@rclient.subscribe = sinon.stub().resolves()
 				p.then () ->
 					done(new Error('should not subscribe but fail'))
 				.catch (err) =>
 					err.message.should.equal "some redis error"
 					@ChannelManager.getClientMapEntry(@rclient).has("applied-ops:1234567890abcdef").should.equal false
 					@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
-					done()
+					# subscribe is wrapped in Promise, delay other assertions
+					setTimeout done
 				return null
 
 			it "should subscribe again", ->
-				@rclient.subscribe.called.should.equal true
+				@rclient.subscribe.callCount.should.equal 2
 				@ChannelManager.getClientMapEntry(@rclient).has("applied-ops:1234567890abcdef").should.equal true
 
 		describe "when subscribe errors and the clientChannelMap entry was replaced", ->
 			beforeEach (done) ->
-				@rclient.subscribe = () ->
-					return new Promise (resolve, reject) ->
-						setTimeout((() -> reject(new Error("some redis error"))), 3)
+				@rclient.subscribe = sinon.stub()
+					.onFirstCall().rejects(new Error("some redis error"))
+					.onSecondCall().resolves()
 				@first = @ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
 				# ignore error
 				@first.catch((()->))
-				@ChannelManager.getClientMapEntry(@rclient).get("applied-ops:1234567890abcdef").should.equal @first
+				expect(@ChannelManager.getClientMapEntry(@rclient).get("applied-ops:1234567890abcdef")).to.equal @first
 
 				@rclient.unsubscribe = sinon.stub().resolves()
-				@rclient.subscribe = sinon.stub().resolves()
 				@ChannelManager.unsubscribe @rclient, "applied-ops", "1234567890abcdef"
 				@second = @ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
-				# replaced immediately
-				@ChannelManager.getClientMapEntry(@rclient).get("applied-ops:1234567890abcdef").should.equal @second
+				# should get replaced immediately
+				expect(@ChannelManager.getClientMapEntry(@rclient).get("applied-ops:1234567890abcdef")).to.equal @second
 
 				# let the first subscribe error -> unsubscribe -> subscribe
-				setTimeout done, 10
+				setTimeout done
 
 			it "should not cleanup the second subscribePromise", ->
-				@ChannelManager.getClientMapEntry(@rclient).get("applied-ops:1234567890abcdef").should.equal @second
+				expect(@ChannelManager.getClientMapEntry(@rclient).get("applied-ops:1234567890abcdef")).to.equal @second
 
 		describe "when there is an existing subscription for another redis client but not this one", ->
-			beforeEach ->
+			beforeEach (done) ->
 				@other_rclient.subscribe = sinon.stub().resolves()
 				@ChannelManager.subscribe @other_rclient, "applied-ops", "1234567890abcdef"
 				@rclient.subscribe = sinon.stub().resolves()  # discard the original stub
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
+				setTimeout done
 
 			it "should subscribe to the redis channel on this redis client", ->
 				@rclient.subscribe.calledWithExactly("applied-ops:1234567890abcdef").should.equal true
@@ -90,23 +91,73 @@ describe 'ChannelManager', ->
 	describe "unsubscribe", ->
 
 		describe "when there is no existing subscription for this redis client", ->
-			beforeEach ->
+			beforeEach (done) ->
 				@rclient.unsubscribe = sinon.stub()
 				@ChannelManager.unsubscribe @rclient, "applied-ops", "1234567890abcdef"
+				setTimeout done
 
 			it "should not unsubscribe from the redis channel", ->
 				@rclient.unsubscribe.called.should.equal false
 
 
 		describe "when there is an existing subscription for this another redis client but not this one", ->
-			beforeEach ->
+			beforeEach (done) ->
 				@other_rclient.subscribe = sinon.stub().resolves()
 				@rclient.unsubscribe = sinon.stub()
 				@ChannelManager.subscribe @other_rclient, "applied-ops", "1234567890abcdef"
 				@ChannelManager.unsubscribe @rclient, "applied-ops", "1234567890abcdef"
+				setTimeout done
 
 			it "should not unsubscribe from the redis channel on this client", ->
 				@rclient.unsubscribe.called.should.equal false
+
+		describe "when unsubscribe errors and completes", ->
+			beforeEach (done) ->
+				@rclient.subscribe = sinon.stub().resolves()
+				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
+				@rclient.unsubscribe = sinon.stub().rejects(new Error("some redis error"))
+				@ChannelManager.unsubscribe @rclient, "applied-ops", "1234567890abcdef"
+				setTimeout done
+				return null
+
+			it "should have cleaned up", ->
+				@ChannelManager.getClientMapEntry(@rclient).has("applied-ops:1234567890abcdef").should.equal false
+
+			it "should not error out when subscribing again", (done) ->
+				p = @ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
+				p.then () ->
+					done()
+				.catch done
+				return null
+
+		describe "when unsubscribe errors and another client subscribes at the same time", ->
+			beforeEach (done) ->
+				@rclient.subscribe = sinon.stub().resolves()
+				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
+				rejectSubscribe = undefined
+				@rclient.unsubscribe = () ->
+					return new Promise (resolve, reject) ->
+						rejectSubscribe = reject
+				@ChannelManager.unsubscribe @rclient, "applied-ops", "1234567890abcdef"
+
+				setTimeout () =>
+					# delay, actualUnsubscribe should not see the new subscribe request
+					# (otherwise it will skip the unsubscribe call as an optimization)
+					@ChannelManager.subscribe(@rclient, "applied-ops", "1234567890abcdef")
+					.then () ->
+						setTimeout done
+					.catch done
+					setTimeout ->
+						# delay, rejectSubscribe is not defined immediately
+						rejectSubscribe(new Error("redis error"))
+				return null
+
+			it "should have errored", ->
+				expect(@metrics.inc.calledWithExactly("unsubscribe.failed.applied-ops")).to.equal(true)
+
+			it "should have subscribed and stored the success", ->
+				@rclient.subscribe.called.should.equal true
+				@ChannelManager.getClientMapEntry(@rclient).has("applied-ops:1234567890abcdef").should.equal true
 
 		describe "when there is an existing subscription for this redis client", ->
 			beforeEach (done) ->
@@ -114,7 +165,7 @@ describe 'ChannelManager', ->
 				@rclient.unsubscribe = sinon.stub().resolves()
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
 				@ChannelManager.unsubscribe @rclient, "applied-ops", "1234567890abcdef"
-				setTimeout done, 3
+				setTimeout done
 
 			it "should unsubscribe from the redis channel", ->
 				@rclient.unsubscribe.calledWithExactly("applied-ops:1234567890abcdef").should.equal true
@@ -234,7 +285,7 @@ describe 'ChannelManager', ->
 					beforeEach (done) ->
 						setTimeout () =>
 							@redisSubscribePromises[0].resolve()
-							setTimeout done, 3
+							setTimeout done
 						, 3
 						return null # ... no implicit return
 
@@ -263,7 +314,7 @@ describe 'ChannelManager', ->
 						beforeEach (done) ->
 							setTimeout () =>
 								@redisSubscribePromises[0].resolve()
-								setTimeout done, 3
+								setTimeout done
 							, 3
 							return null # ... no implicit return
 
@@ -279,8 +330,7 @@ describe 'ChannelManager', ->
 							beforeEach (done) ->
 								setTimeout () =>
 									@redisSubscribePromises[1].resolve()
-									setTimeout done, 3
-								, 3
+									setTimeout done
 								return null # ... no implicit return
 
 							it "should finish subscribePromise for doc2", (done) ->
@@ -309,7 +359,7 @@ describe 'ChannelManager', ->
 					beforeEach (done) ->
 						setTimeout () =>
 							@redisSubscribePromises[0].resolve()
-							setTimeout done, 3
+							setTimeout done
 						, 3
 						return null # ... no implicit return
 
@@ -336,7 +386,7 @@ describe 'ChannelManager', ->
 						beforeEach (done) ->
 							setTimeout () =>
 								@redisSubscribePromises[1].resolve()
-								setTimeout done, 3
+								setTimeout done
 							, 5
 							return null # ... no implicit return
 
@@ -368,7 +418,7 @@ describe 'ChannelManager', ->
 				beforeEach (done) ->
 					setTimeout () =>
 						@redisSubscribePromises[0].resolve()
-						setTimeout done, 3
+						setTimeout done
 					, 3
 					return null # ... no implicit return
 
@@ -387,7 +437,7 @@ describe 'ChannelManager', ->
 					beforeEach (done) ->
 						setTimeout () =>
 							@redisUnsubscribePromises[0].resolve()
-							setTimeout done, 3
+							setTimeout done
 						, 3
 						return null # ... no implicit return
 
@@ -402,25 +452,7 @@ describe 'ChannelManager', ->
 					it "should have cleared the tear down state", () ->
 						expect(@clientChannelMapTearDown.has(@channel1)).to.equal false
 
-		describe "when lots of requests race", ->
-			beforeEach () ->
-				@subscribePromise1 = @ChannelManager.subscribe(@rclient, entity, @id1)
-				@ChannelManager.unsubscribe(@rclient, entity, @id1)
-				@tearDownPromise1 = @clientChannelMapTearDown.get(@channel1)
-
-				@subscribePromise2 = @ChannelManager.subscribe(@rclient, entity, @id1)
-				@ChannelManager.unsubscribe(@rclient, entity, @id1)
-				@tearDownPromise2 = @clientChannelMapTearDown.get(@channel1)
-
-				@subscribePromise3 = @ChannelManager.subscribe(@rclient, entity, @id1)
-				@ChannelManager.unsubscribe(@rclient, entity, @id1)
-				@tearDownPromise3 = @clientChannelMapTearDown.get(@channel1)
-
-				@subscribePromise4 = @ChannelManager.subscribe(@rclient, entity, @id1)
-				@ChannelManager.unsubscribe(@rclient, entity, @id1)
-				@tearDownPromise4 = @clientChannelMapTearDown.get(@channel1)
-				return null # ... no implicit return
-
+		verifyConsistentBehaviour = ->
 			it "should not finish any subscribePromise", (done) ->
 				{sentinel, p} = getPromiseThatResolvesASentinelSoon()
 				Promise.race([@subscribePromise1, @subscribePromise2, @subscribePromise3, @subscribePromise4, p])
@@ -439,7 +471,7 @@ describe 'ChannelManager', ->
 				beforeEach (done) ->
 					setTimeout () =>
 						@redisSubscribePromises[0].resolve()
-						setTimeout done, 3
+						setTimeout done
 					, 3
 					return null # ... no implicit return
 
@@ -479,7 +511,7 @@ describe 'ChannelManager', ->
 							@redisSubscribePromises[1].resolve()
 							setTimeout () =>
 								@redisSubscribePromises[2].resolve()
-								setTimeout done, 3
+								setTimeout done
 							, 3
 						, 3
 						return null # ... no implicit return
@@ -502,7 +534,7 @@ describe 'ChannelManager', ->
 						beforeEach (done) ->
 							setTimeout () =>
 								@redisSubscribePromises[3].resolve()
-								setTimeout done, 3
+								setTimeout done
 							, 3
 							return null # ... no implicit return
 
@@ -532,8 +564,7 @@ describe 'ChannelManager', ->
 								setTimeout () =>
 									# actually there is just one redis unsubscribe call
 									@redisUnsubscribePromises[0].resolve()
-									setTimeout done, 3
-								, 3
+									setTimeout done
 								return null # ... no implicit return
 
 							it "should have finished unsubscribing", (done) ->
@@ -546,3 +577,85 @@ describe 'ChannelManager', ->
 
 							it "should have cleared the tear down state", () ->
 								expect(@clientChannelMapTearDown.has(@channel1)).to.equal false
+
+		describe "when lots of requests race in a single event loop cycle (synchronous)", ->
+			beforeEach (done) ->
+				@subscribePromise1 = @ChannelManager.subscribe(@rclient, entity, @id1)
+				@ChannelManager.unsubscribe(@rclient, entity, @id1)
+				@tearDownPromise1 = @clientChannelMapTearDown.get(@channel1)
+
+				@subscribePromise2 = @ChannelManager.subscribe(@rclient, entity, @id1)
+				@ChannelManager.unsubscribe(@rclient, entity, @id1)
+				@tearDownPromise2 = @clientChannelMapTearDown.get(@channel1)
+
+				@subscribePromise3 = @ChannelManager.subscribe(@rclient, entity, @id1)
+				@ChannelManager.unsubscribe(@rclient, entity, @id1)
+				@tearDownPromise3 = @clientChannelMapTearDown.get(@channel1)
+
+				@subscribePromise4 = @ChannelManager.subscribe(@rclient, entity, @id1)
+				@ChannelManager.unsubscribe(@rclient, entity, @id1)
+				@tearDownPromise4 = @clientChannelMapTearDown.get(@channel1)
+				setTimeout done
+				return null # ... no implicit return
+
+			verifyConsistentBehaviour()
+
+		describe "when lots of requests race with process.nextTick in between", ->
+			beforeEach (done) ->
+				@subscribePromise1 = @ChannelManager.subscribe(@rclient, entity, @id1)
+				process.nextTick =>
+					@ChannelManager.unsubscribe(@rclient, entity, @id1)
+					@tearDownPromise1 = @clientChannelMapTearDown.get(@channel1)
+
+					process.nextTick =>
+						@subscribePromise2 = @ChannelManager.subscribe(@rclient, entity, @id1)
+						process.nextTick =>
+							@ChannelManager.unsubscribe(@rclient, entity, @id1)
+							@tearDownPromise2 = @clientChannelMapTearDown.get(@channel1)
+
+							process.nextTick =>
+								@subscribePromise3 = @ChannelManager.subscribe(@rclient, entity, @id1)
+								process.nextTick =>
+									@ChannelManager.unsubscribe(@rclient, entity, @id1)
+									@tearDownPromise3 = @clientChannelMapTearDown.get(@channel1)
+
+									process.nextTick =>
+										@subscribePromise4 = @ChannelManager.subscribe(@rclient, entity, @id1)
+										process.nextTick =>
+											@ChannelManager.unsubscribe(@rclient, entity, @id1)
+											@tearDownPromise4 = @clientChannelMapTearDown.get(@channel1)
+
+											# let some Promise.then calls run
+											setTimeout done
+				return null # ... no implicit return
+
+			verifyConsistentBehaviour()
+
+		describe "when lots of requests race with network dispatches in between", ->
+			beforeEach (done) ->
+				@subscribePromise1 = @ChannelManager.subscribe(@rclient, entity, @id1)
+				setTimeout =>
+					@ChannelManager.unsubscribe(@rclient, entity, @id1)
+					@tearDownPromise1 = @clientChannelMapTearDown.get(@channel1)
+
+					setTimeout =>
+						@subscribePromise2 = @ChannelManager.subscribe(@rclient, entity, @id1)
+						setTimeout =>
+							@ChannelManager.unsubscribe(@rclient, entity, @id1)
+							@tearDownPromise2 = @clientChannelMapTearDown.get(@channel1)
+
+							setTimeout =>
+								@subscribePromise3 = @ChannelManager.subscribe(@rclient, entity, @id1)
+								setTimeout =>
+									@ChannelManager.unsubscribe(@rclient, entity, @id1)
+									@tearDownPromise3 = @clientChannelMapTearDown.get(@channel1)
+
+									setTimeout =>
+										@subscribePromise4 = @ChannelManager.subscribe(@rclient, entity, @id1)
+										setTimeout =>
+											@ChannelManager.unsubscribe(@rclient, entity, @id1)
+											@tearDownPromise4 = @clientChannelMapTearDown.get(@channel1)
+											setTimeout done
+				return null # ... no implicit return
+
+			verifyConsistentBehaviour()

--- a/test/unit/coffee/ChannelManagerTests.coffee
+++ b/test/unit/coffee/ChannelManagerTests.coffee
@@ -1,5 +1,6 @@
 chai = require('chai')
 should = chai.should()
+expect = chai.expect
 sinon = require("sinon")
 modulePath = "../../../app/js/ChannelManager.js"
 SandboxedModule = require('sandboxed-module')
@@ -108,11 +109,12 @@ describe 'ChannelManager', ->
 				@rclient.unsubscribe.called.should.equal false
 
 		describe "when there is an existing subscription for this redis client", ->
-			beforeEach ->
+			beforeEach (done) ->
 				@rclient.subscribe = sinon.stub().resolves()
-				@rclient.unsubscribe = sinon.stub()
+				@rclient.unsubscribe = sinon.stub().resolves()
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
 				@ChannelManager.unsubscribe @rclient, "applied-ops", "1234567890abcdef"
+				setTimeout done, 3
 
 			it "should unsubscribe from the redis channel", ->
 				@rclient.unsubscribe.calledWithExactly("applied-ops:1234567890abcdef").should.equal true
@@ -159,3 +161,388 @@ describe 'ChannelManager', ->
 					"redis.publish.applied-ops",
 					"random-message".length
 				).should.equal true
+
+	describe "strictSequence", ->
+		entity = "applied-ops"
+		getChannel = (id) ->
+			return "#{entity}:#{id}"
+
+		getPromiseThatResolvesASentinelSoon = () ->
+			sentinel = Math.random()
+			p = new Promise (resolve) ->
+				setTimeout () ->
+					resolve(sentinel)
+				, 1
+			return {sentinel, p}
+
+		getFloatingPromise = () ->
+			resolve = reject = undefined
+			p = new Promise (_resolve, _reject) ->
+				resolve = _resolve
+				reject = _reject
+			return {p, resolve, reject}
+
+		beforeEach ->
+			@id1 = Math.random().toString()
+			@channel1 = getChannel(@id1)
+			@id2 = Math.random().toString()
+			@channel2 = getChannel(@id1)
+
+			@ChannelManager.getClientMapEntry(@rclient).clear()
+			@ChannelManager.getClientMapTearDownEntry(@rclient).clear()
+			@clientChannelMapTearDown = @ChannelManager.getClientMapTearDownEntry(@rclient)
+
+			@redisSubscribePromises = []
+			@redisUnsubscribePromises = []
+			@rclient.subscribe = () =>
+				{p, resolve, reject} = getFloatingPromise()
+				@redisSubscribePromises.push({p, resolve, reject})
+				return p
+
+			@rclient.unsubscribe = () =>
+				{p, resolve, reject} = getFloatingPromise()
+				@redisUnsubscribePromises.push({p, resolve, reject})
+				return p
+
+		describe "subscribe", ->
+			beforeEach ->
+				@subscribePromise1 = @ChannelManager.subscribe(@rclient, entity, @id1)
+				return null # ... no implicit return
+
+			it "should return a pending Promise", (done) ->
+				{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+				Promise.race([@subscribePromise1, p])
+					.then (result) ->
+						expect(result).to.equal(sentinel)
+						done()
+				return null # ... no implicit return
+
+			describe "when there is another inflight subscribe", ->
+				beforeEach ->
+					@subscribePromise2 = @ChannelManager.subscribe(@rclient, entity, @id1)
+					return null # ... no implicit return
+
+				it "should return another pending Promise", (done) ->
+					{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+					Promise.race([@subscribePromise2, p])
+						.then (result) ->
+							expect(result).to.equal(sentinel)
+							done()
+					return null # ... no implicit return
+
+				describe "when the redis subscribe completes", ->
+					beforeEach (done) ->
+						setTimeout () =>
+							@redisSubscribePromises[0].resolve()
+							setTimeout done, 3
+						, 3
+						return null # ... no implicit return
+
+					it "should finish subscribePromise1", (done) ->
+						{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+						Promise.race([@subscribePromise1, p])
+							.then (result) ->
+								expect(result).to.not.equal(sentinel)
+								done()
+						return null # ... no implicit return
+
+					it "should finish subscribePromise2", (done) ->
+						{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+						Promise.race([@subscribePromise2, p])
+							.then (result) ->
+								expect(result).to.not.equal(sentinel)
+								done()
+						return null # ... no implicit return
+
+				describe "when there is a second doc subscribing", ->
+					beforeEach ->
+						@subscribePromise3 = @ChannelManager.subscribe(@rclient, entity, @id2)
+						return null # ... no implicit return
+
+					describe "when the redis subscribe for doc1 completes", ->
+						beforeEach (done) ->
+							setTimeout () =>
+								@redisSubscribePromises[0].resolve()
+								setTimeout done, 3
+							, 3
+							return null # ... no implicit return
+
+						it "should not finish subscribePromise for doc2", (done) ->
+							{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+							Promise.race([@subscribePromise3, p])
+								.then (result) ->
+									expect(result).to.equal(sentinel)
+									done()
+							return null # ... no implicit return
+
+						describe "when the redis subscribe for doc2 completes", ->
+							beforeEach (done) ->
+								setTimeout () =>
+									@redisSubscribePromises[1].resolve()
+									setTimeout done, 3
+								, 3
+								return null # ... no implicit return
+
+							it "should finish subscribePromise for doc2", (done) ->
+								{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+								Promise.race([@subscribePromise3, p])
+									.then (result) ->
+										expect(result).to.not.equal(sentinel)
+										done()
+								return null # ... no implicit return
+
+			describe "when there is an unsubscribe in between", ->
+				beforeEach ->
+					@ChannelManager.unsubscribe(@rclient, entity, @id1)
+					@subscribePromise2 = @ChannelManager.subscribe(@rclient, entity, @id1)
+					return null # ... no implicit return
+
+				it "should return a pending Promise", (done) ->
+					{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+					Promise.race([@subscribePromise2, p])
+						.then (result) ->
+							expect(result).to.equal(sentinel)
+							done()
+					return null # ... no implicit return
+
+				describe "when the subscribe completes", ->
+					beforeEach (done) ->
+						setTimeout () =>
+							@redisSubscribePromises[0].resolve()
+							setTimeout done, 3
+						, 3
+						return null # ... no implicit return
+
+					it "should finish subscribePromise1", (done) ->
+						{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+						Promise.race([@subscribePromise1, p])
+							.then (result) ->
+								expect(result).to.not.equal(sentinel)
+								done()
+						return null # ... no implicit return
+
+					it "should not finish subscribePromise2 yet", (done) ->
+						{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+						Promise.race([@subscribePromise2, p])
+							.then (result) ->
+								expect(result).to.equal(sentinel)
+								done()
+						return null # ... no implicit return
+
+					it "should skip the unsubscribe call", () ->
+						expect(@redisUnsubscribePromises).to.deep.equal([])
+
+					describe "when the 2nd redis subscribe complete", ->
+						beforeEach (done) ->
+							setTimeout () =>
+								@redisSubscribePromises[1].resolve()
+								setTimeout done, 3
+							, 5
+							return null # ... no implicit return
+
+						it "should finish subscribePromise2", (done) ->
+							{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+							Promise.race([@subscribePromise2, p])
+								.then (result) ->
+									expect(result).to.not.equal(sentinel)
+									done()
+							return null # ... no implicit return
+
+		describe "unsubscribe", ->
+			beforeEach ->
+				@subscribePromise1 = @ChannelManager.subscribe(@rclient, entity, @id1)
+				@returnValue = @ChannelManager.unsubscribe(@rclient, entity, @id1)
+				@tearDownPromise1 = @clientChannelMapTearDown.get(@channel1)
+				return null # ... no implicit return
+
+			it "should return immediately", () ->
+				expect(@returnValue).to.be.undefined
+
+			it "should wait for the subscribe to complete", () ->
+				expect(@redisUnsubscribePromises).to.deep.equal([])
+
+			it "should schedule the unsubscribe", () ->
+				expect(@clientChannelMapTearDown.has(@channel1)).to.equal.true
+
+			describe "when the redis subscribe completes", ->
+				beforeEach (done) ->
+					setTimeout () =>
+						@redisSubscribePromises[0].resolve()
+						setTimeout done, 3
+					, 3
+					return null # ... no implicit return
+
+				it "should start unsubscribing", () ->
+					expect(@redisUnsubscribePromises.length).to.equal(1)
+
+				it "should not complete the unsubscribe yet", (done) ->
+					{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+					Promise.race([@tearDownPromise1, p])
+						.then (result) ->
+							expect(result).to.equal(sentinel)
+							done()
+					return null # ... no implicit return
+
+				describe "when the redis unsubscribe completes", ->
+					beforeEach (done) ->
+						setTimeout () =>
+							@redisUnsubscribePromises[0].resolve()
+							setTimeout done, 3
+						, 3
+						return null # ... no implicit return
+
+					it "should have finished unsubscribing", (done) ->
+						{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+						Promise.race([@tearDownPromise1, p])
+							.then (result) ->
+								expect(result).to.not.equal(sentinel)
+								done()
+						return null # ... no implicit return
+
+					it "should have cleared the tear down state", () ->
+						expect(@clientChannelMapTearDown.has(@channel1)).to.equal false
+
+		describe "when lots of requests race", ->
+			beforeEach () ->
+				@subscribePromise1 = @ChannelManager.subscribe(@rclient, entity, @id1)
+				@ChannelManager.unsubscribe(@rclient, entity, @id1)
+				@tearDownPromise1 = @clientChannelMapTearDown.get(@channel1)
+
+				@subscribePromise2 = @ChannelManager.subscribe(@rclient, entity, @id1)
+				@ChannelManager.unsubscribe(@rclient, entity, @id1)
+				@tearDownPromise2 = @clientChannelMapTearDown.get(@channel1)
+
+				@subscribePromise3 = @ChannelManager.subscribe(@rclient, entity, @id1)
+				@ChannelManager.unsubscribe(@rclient, entity, @id1)
+				@tearDownPromise3 = @clientChannelMapTearDown.get(@channel1)
+
+				@subscribePromise4 = @ChannelManager.subscribe(@rclient, entity, @id1)
+				@ChannelManager.unsubscribe(@rclient, entity, @id1)
+				@tearDownPromise4 = @clientChannelMapTearDown.get(@channel1)
+				return null # ... no implicit return
+
+			it "should not finish any subscribePromise", (done) ->
+				{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+				Promise.race([@subscribePromise1, @subscribePromise2, @subscribePromise3, @subscribePromise4, p])
+					.then (result) ->
+						expect(result).to.equal(sentinel)
+						done()
+				return null # ... no implicit return
+
+			it "should wait for the first subscribe to complete before subscribing again", () ->
+				expect(@redisSubscribePromises.length).to.equal(1)
+
+			it "should wait for the first subscribe to complete before unsubscribing", () ->
+				expect(@redisUnsubscribePromises).to.deep.equal([])
+
+			describe "when the first redis subscribe completes", ->
+				beforeEach (done) ->
+					setTimeout () =>
+						@redisSubscribePromises[0].resolve()
+						setTimeout done, 3
+					, 3
+					return null # ... no implicit return
+
+				it "should finish subscribePromise1", (done) ->
+					{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+					Promise.race([@subscribePromise1, p])
+						.then (result) ->
+							expect(result).to.not.equal(sentinel)
+							done()
+					return null # ... no implicit return
+
+				it "should not finish any other subscribePromise", (done) ->
+					{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+					Promise.race([@subscribePromise2, @subscribePromise3, @subscribePromise4, p])
+						.then (result) ->
+							expect(result).to.equal(sentinel)
+							done()
+					return null # ... no implicit return
+
+				it "should skip unsubscribing", () ->
+					expect(@redisUnsubscribePromises).to.deep.equal([])
+
+				it "should complete the unsubscribe immediately", (done) ->
+					{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+					Promise.race([@tearDownPromise1, p])
+						.then (result) ->
+							expect(result).to.not.equal(sentinel)
+							done()
+					return null # ... no implicit return
+
+				it "should not have cleared the tear down state", () ->
+					expect(@clientChannelMapTearDown.has(@channel1)).to.equal true
+
+				describe "when the second and third redis subscribe completes", ->
+					beforeEach (done) ->
+						setTimeout () =>
+							@redisSubscribePromises[1].resolve()
+							setTimeout () =>
+								@redisSubscribePromises[2].resolve()
+								setTimeout done, 3
+							, 3
+						, 3
+						return null # ... no implicit return
+
+					it "should still skip unsubscribing", () ->
+						expect(@redisUnsubscribePromises).to.deep.equal([])
+
+					it "should complete the 2nd and 3rd unsubscribes immediately", (done) ->
+						{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+						Promise.race([@tearDownPromise2, @tearDownPromise3, p])
+							.then (result) ->
+								expect(result).to.not.equal(sentinel)
+								done()
+						return null # ... no implicit return
+
+					it "should not have cleared the tear down state", () ->
+						expect(@clientChannelMapTearDown.has(@channel1)).to.equal true
+
+					describe "when the last redis subscribe completed", ->
+						beforeEach (done) ->
+							setTimeout () =>
+								@redisSubscribePromises[3].resolve()
+								setTimeout done, 3
+							, 3
+							return null # ... no implicit return
+
+						it "should have finished all subscribePromises", (done) ->
+							Promise.all([@subscribePromise1, @subscribePromise2, @subscribePromise3, @subscribePromise4])
+								.then () ->
+									# will timeout when the promises are not ready yet
+									done()
+							return null # ... no implicit return
+
+						it "should start unsubscribing", () ->
+							expect(@redisUnsubscribePromises.length).to.equal(1)
+
+						it "should not complete the unsubscribe yet", (done) ->
+							{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+							Promise.race([@tearDownPromise4, p])
+								.then (result) ->
+									expect(result).to.equal(sentinel)
+									done()
+							return null # ... no implicit return
+
+						it "should not have cleared the tear down state yet", () ->
+							expect(@clientChannelMapTearDown.has(@channel1)).to.equal true
+
+						describe "when the last redis unsubscribe completes", ->
+							beforeEach (done) ->
+								setTimeout () =>
+									# actually there is just one redis unsubscribe call
+									@redisUnsubscribePromises[0].resolve()
+									setTimeout done, 3
+								, 3
+								return null # ... no implicit return
+
+							it "should have finished unsubscribing", (done) ->
+								{sentinel, p} = getPromiseThatResolvesASentinelSoon()
+								Promise.race([@tearDownPromise4, p])
+									.then (result) ->
+										expect(result).to.not.equal(sentinel)
+										done()
+								return null # ... no implicit return
+
+							it "should have cleared the tear down state", () ->
+								expect(@clientChannelMapTearDown.has(@channel1)).to.equal false


### PR DESCRIPTION
### Description

Chained onto #132 

This PR implements a strict sequence of subscribe and unsubscribe calls.

It is a safe guard for future work of arbitrary cleanup calls.

Subscribe waits for unsubscribe requests. Unsubscribe waits for
 subscribe requests. Unsubscribe breaks the chain.

Additionally I added shortcuts into the unsubscribe process to skip the redis request
 when we detect a race/overtaking request. This is important for the future delayed
 unsubscribe calls -- they should not block any new subscribes or do duplicate work.

1st subscribe -> 1st unsubscribe -> 2nd subscribe -> 2nd unsubscribe

We can skip the 1st unsubscribe, when the 2nd subscribe came in before the 1st subscribe completed. We can also skip the 1st unsubscribe when the 2nd unsubscribe came in before the 1st subscribe completed.

#### Review

I could not find a simple way to tell whether a Promise completed already, so there is a home grown solution which lets a given Promise race against another that completes 1ms later.
I am happy to replace it with something simpler. Moving to a new coffee-script version or decaff would enable `async function`s, but we are not there yet.

Regarding the acceptance tests:

`test/acceptance/coffee/PubSubRace.coffee -> when the client disconnects before joinDoc completes`:

Due to different code paths in socket.io for `joinProject` and `disconnect` requests from the client, we are very likely not getting into a race (two vs one process.nextTick calls).

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3002

#### Potential Impact

High. clients could be connected without getting any updates.

#### Manual Testing Performed

- added lots of unit tests
- a new acceptance test suite
- open lots of editor tabs, they should not see each other
