### PR TITLE
[WebsocketController] skip leaveProject when joinProject didn't complete

### DIFF
--- a/test/unit/coffee/WebsocketControllerTests.coffee
+++ b/test/unit/coffee/WebsocketControllerTests.coffee
@@ -143,6 +143,19 @@ describe 'WebsocketController', ->
 			@WebsocketController.FLUSH_IF_EMPTY_DELAY = 0
 			tk.reset() # Allow setTimeout to work.
 
+		describe "when the client did not joined a project yet", ->
+			beforeEach (done) ->
+				@client.params = {}
+				@WebsocketController.leaveProject @io, @client, done
+
+			it "should bail out when calling leaveProject", () ->
+				@WebsocketLoadBalancer.emitToRoom.called.should.equal false
+				@RoomManager.leaveProjectAndDocs.called.should.equal false
+				@ConnectedUsersManager.markUserAsDisconnected.called.should.equal false
+
+			it "should not inc any metric", () ->
+				@metrics.inc.called.should.equal false
+
 		describe "when the project is empty", ->
 			beforeEach (done) ->
 				@clientsInRoom = []
@@ -201,8 +214,8 @@ describe 'WebsocketController', ->
 					.calledWith(@project_id)
 					.should.equal false
 
-			it "should increment the leave-project metric", ->
-				@metrics.inc.calledWith("editor.leave-project").should.equal true
+			it "should not increment the leave-project metric", ->
+				@metrics.inc.calledWith("editor.leave-project").should.equal false
 
 		describe "when client has not joined a project", ->
 			beforeEach (done) ->
@@ -225,8 +238,8 @@ describe 'WebsocketController', ->
 					.calledWith(@project_id)
 					.should.equal false
 
-			it "should increment the leave-project metric", ->
-				@metrics.inc.calledWith("editor.leave-project").should.equal true
+			it "should not increment the leave-project metric", ->
+				@metrics.inc.calledWith("editor.leave-project").should.equal false
 
 	describe "joinDoc", ->
 		beforeEach ->


### PR DESCRIPTION
#### Description

We are seeing random spikes in the metrics from clients connecting, but never actually authenticating/joining. Upon disconnect we are calling leaveProject to cleanup, which may not be actually needed, when the client did not call joinProject yet.

I attached a `joinedProject` attribute to the client when the web api call succeeded. Only there after we are actually populating client params and joining rooms.

#### Review

Putting the `joinedProject` flag into the regular client params would require indent changes to get the value back in an async way.

Alternative approach: We could move `metrics.inc "editor.leave-project"` into `Utils.getClientAttributes` and use a regular param then.


#### Potential Impact

High, missing cleanup could lead to memory leaks.


#### Manual Testing Performed

- added unit test
