### PR TITLE
[misc] merge master into v2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,3 @@
-[app/coffee/ChannelManager.coffee]
-indent_style = space
-indent_size = 4
-
 [app/coffee/RoomManager.coffee]
 indent_style = space
 indent_size = 4

--- a/app/coffee/ChannelManager.coffee
+++ b/app/coffee/ChannelManager.coffee
@@ -31,11 +31,13 @@ module.exports = ChannelManager =
             clientChannelMap.set(channel, subscribePromise)
             logger.log {channel}, "subscribed to new channel"
             metrics.inc "subscribe.#{baseChannel}"
-            subscribePromise.catch () ->
-                metrics.inc "subscribe.failed.#{baseChannel}"
-                # clear state
-                clientChannelMap.delete(channel)
-            return subscribePromise
+            return new Promise (resolve, reject) ->
+                subscribePromise.then(resolve)
+                subscribePromise.catch (err) ->
+                    metrics.inc "subscribe.failed.#{baseChannel}"
+                    # clear state
+                    clientChannelMap.delete(channel)
+                    reject(err)
 
     unsubscribe: (rclient, baseChannel, id) ->
         clientChannelMap = @getClientMapEntry(rclient)

--- a/app/coffee/ChannelManager.coffee
+++ b/app/coffee/ChannelManager.coffee
@@ -31,13 +31,7 @@ module.exports = ChannelManager =
             clientChannelMap.set(channel, subscribePromise)
             logger.log {channel}, "subscribed to new channel"
             metrics.inc "subscribe.#{baseChannel}"
-            return new Promise (resolve, reject) ->
-                subscribePromise.then(resolve)
-                subscribePromise.catch (err) ->
-                    metrics.inc "subscribe.failed.#{baseChannel}"
-                    # clear state
-                    clientChannelMap.delete(channel)
-                    reject(err)
+            return subscribePromise
 
     unsubscribe: (rclient, baseChannel, id) ->
         clientChannelMap = @getClientMapEntry(rclient)

--- a/app/coffee/WebsocketController.coffee
+++ b/app/coffee/WebsocketController.coffee
@@ -40,6 +40,7 @@ module.exports = WebsocketController =
 			client.ol_context["is_restricted_user"] = !!(isRestrictedUser)
 
 			RoomManager.joinProject client, project_id, (err) ->
+				return callback(err) if err
 				logger.log {user_id, project_id, client_id: client.id}, "user joined project"
 				callback null, project, privilegeLevel, WebsocketController.PROTOCOL_VERSION
 

--- a/app/coffee/WebsocketController.coffee
+++ b/app/coffee/WebsocketController.coffee
@@ -52,21 +52,12 @@ module.exports = WebsocketController =
 	# is determined by FLUSH_IF_EMPTY_DELAY.
 	FLUSH_IF_EMPTY_DELAY: 500 #ms
 	leaveProject: (io, client, callback = (error) ->) ->
-			metrics.inc "editor.leave-project"
 			{project_id, user_id} = client.ol_context
+			return callback() unless project_id # client did not join project
 
+			metrics.inc "editor.leave-project"
 			logger.log {project_id, user_id, client_id: client.id}, "client leaving project"
 			WebsocketLoadBalancer.emitToRoom project_id, "clientTracking.clientDisconnected", client.id
-
-			# bail out if the client had not managed to authenticate or join
-			# the project.  Prevents downstream errors in docupdater from
-			# flushProjectToMongoAndDelete with null project_id.
-			if not user_id?
-				logger.log {client_id: client.id}, "client leaving, unknown user"
-				return callback()
-			if not project_id?
-				logger.log {user_id: user_id, client_id: client.id}, "client leaving, not in project"
-				return callback()
 
 			# We can do this in the background
 			ConnectedUsersManager.markUserAsDisconnected project_id, client.id, (err) ->

--- a/test/acceptance/coffee/PubSubRace.coffee
+++ b/test/acceptance/coffee/PubSubRace.coffee
@@ -1,0 +1,205 @@
+RealTimeClient = require "./helpers/RealTimeClient"
+MockDocUpdaterServer = require "./helpers/MockDocUpdaterServer"
+FixturesManager = require "./helpers/FixturesManager"
+
+async = require "async"
+
+settings = require "settings-sharelatex"
+redis = require "redis-sharelatex"
+rclient = redis.createClient(settings.redis.pubsub)
+
+describe "PubSubRace", ->
+	before (done) ->
+		MockDocUpdaterServer.run done
+
+	describe "when the client leaves a doc before joinDoc completes", ->
+		before (done) ->
+			async.series [
+				(cb) =>
+					FixturesManager.setUpProject {
+						privilegeLevel: "owner"
+						project: {
+							name: "Test Project"
+						}
+					}, (e, {@project_id, @user_id}) => cb()
+
+				(cb) =>
+					@clientA = RealTimeClient.connect()
+					@clientA.on "connect", cb
+
+				(cb) =>
+					@clientA.emit "joinProject", project_id: @project_id, (error, @project, @privilegeLevel, @protocolVersion) =>
+						cb(error)
+
+				(cb) =>
+					FixturesManager.setUpDoc @project_id, {@lines, @version, @ops}, (e, {@doc_id}) =>
+						cb(e)
+
+				(cb) =>
+					@clientA.emit "joinDoc", @doc_id, () ->
+					# leave before joinDoc completes
+					@clientA.emit "leaveDoc", @doc_id, cb
+
+				(cb) =>
+					# wait for subscribe and unsubscribe
+					setTimeout cb, 100
+			], done
+
+		it "should not subscribe to the applied-ops channels anymore", (done) ->
+			rclient.pubsub 'CHANNELS', (err, resp) =>
+				return done(err) if err
+				resp.should.not.include "applied-ops:#{@doc_id}"
+				done()
+			return null
+
+	describe "when the client emits joinDoc and leaveDoc requests frequently and leaves eventually", ->
+		before (done) ->
+			async.series [
+				(cb) =>
+					FixturesManager.setUpProject {
+						privilegeLevel: "owner"
+						project: {
+							name: "Test Project"
+						}
+					}, (e, {@project_id, @user_id}) => cb()
+
+				(cb) =>
+					@clientA = RealTimeClient.connect()
+					@clientA.on "connect", cb
+
+				(cb) =>
+					@clientA.emit "joinProject", project_id: @project_id, (error, @project, @privilegeLevel, @protocolVersion) =>
+						cb(error)
+
+				(cb) =>
+					FixturesManager.setUpDoc @project_id, {@lines, @version, @ops}, (e, {@doc_id}) =>
+						cb(e)
+
+				(cb) =>
+					@clientA.emit "joinDoc", @doc_id, () ->
+					@clientA.emit "leaveDoc", @doc_id, () ->
+					@clientA.emit "joinDoc", @doc_id, () ->
+					@clientA.emit "leaveDoc", @doc_id, () ->
+					@clientA.emit "joinDoc", @doc_id, () ->
+					@clientA.emit "leaveDoc", @doc_id, () ->
+					@clientA.emit "joinDoc", @doc_id, () ->
+					@clientA.emit "leaveDoc", @doc_id, () ->
+					@clientA.emit "joinDoc", @doc_id, () ->
+					@clientA.emit "leaveDoc", @doc_id, cb
+
+				(cb) =>
+					# wait for subscribe and unsubscribe
+					setTimeout cb, 100
+			], done
+
+		it "should not subscribe to the applied-ops channels anymore", (done) ->
+			rclient.pubsub 'CHANNELS', (err, resp) =>
+				return done(err) if err
+				resp.should.not.include "applied-ops:#{@doc_id}"
+				done()
+			return null
+
+	describe "when the client emits joinDoc and leaveDoc requests frequently and remains in the doc", ->
+		before (done) ->
+			async.series [
+				(cb) =>
+					FixturesManager.setUpProject {
+						privilegeLevel: "owner"
+						project: {
+							name: "Test Project"
+						}
+					}, (e, {@project_id, @user_id}) => cb()
+
+				(cb) =>
+					@clientA = RealTimeClient.connect()
+					@clientA.on "connect", cb
+
+				(cb) =>
+					@clientA.emit "joinProject", project_id: @project_id, (error, @project, @privilegeLevel, @protocolVersion) =>
+						cb(error)
+
+				(cb) =>
+					FixturesManager.setUpDoc @project_id, {@lines, @version, @ops}, (e, {@doc_id}) =>
+						cb(e)
+
+				(cb) =>
+					@clientA.emit "joinDoc", @doc_id, () ->
+					@clientA.emit "leaveDoc", @doc_id, () ->
+					@clientA.emit "joinDoc", @doc_id, () ->
+					@clientA.emit "leaveDoc", @doc_id, () ->
+					@clientA.emit "joinDoc", @doc_id, () ->
+					@clientA.emit "leaveDoc", @doc_id, () ->
+					@clientA.emit "joinDoc", @doc_id, () ->
+					@clientA.emit "leaveDoc", @doc_id, () ->
+					@clientA.emit "joinDoc", @doc_id, cb
+
+				(cb) =>
+					# wait for subscribe and unsubscribe
+					setTimeout cb, 100
+			], done
+
+		it "should subscribe to the applied-ops channels", (done) ->
+			rclient.pubsub 'CHANNELS', (err, resp) =>
+				return done(err) if err
+				resp.should.include "applied-ops:#{@doc_id}"
+				done()
+			return null
+
+	describe "when the client disconnects before joinDoc completes", ->
+		before (done) ->
+			async.series [
+				(cb) =>
+					FixturesManager.setUpProject {
+						privilegeLevel: "owner"
+						project: {
+							name: "Test Project"
+						}
+					}, (e, {@project_id, @user_id}) => cb()
+
+				(cb) =>
+					@clientA = RealTimeClient.connect()
+					@clientA.on "connect", cb
+
+				(cb) =>
+					@clientA.emit "joinProject", project_id: @project_id, (error, @project, @privilegeLevel, @protocolVersion) =>
+						cb(error)
+
+				(cb) =>
+					FixturesManager.setUpDoc @project_id, {@lines, @version, @ops}, (e, {@doc_id}) =>
+						cb(e)
+
+				(cb) =>
+					joinDocCompleted = false
+					@clientA.emit "joinDoc", @doc_id, () ->
+						joinDocCompleted = true
+					# leave before joinDoc completes
+					setTimeout () =>
+						if joinDocCompleted
+							return cb(new Error('joinDocCompleted -- lower timeout'))
+						@clientA.on "disconnect", () -> cb()
+						@clientA.disconnect()
+					# socket.io processes joinDoc and disconnect with different delays:
+					#  - joinDoc goes through two process.nextTick
+					#  - disconnect goes through one process.nextTick
+					# We have to inject the disconnect event into a different event loop
+					#  cycle.
+					, 3
+
+				(cb) =>
+					# wait for subscribe and unsubscribe
+					setTimeout cb, 100
+			], done
+
+		it "should not subscribe to the editor-events channels anymore", (done) ->
+			rclient.pubsub 'CHANNELS', (err, resp) =>
+				return done(err) if err
+				resp.should.not.include "editor-events:#{@project_id}"
+				done()
+			return null
+
+		it "should not subscribe to the applied-ops channels anymore", (done) ->
+			rclient.pubsub 'CHANNELS', (err, resp) =>
+				return done(err) if err
+				resp.should.not.include "applied-ops:#{@doc_id}"
+				done()
+			return null

--- a/test/unit/coffee/ChannelManagerTests.coffee
+++ b/test/unit/coffee/ChannelManagerTests.coffee
@@ -1,5 +1,6 @@
 chai = require('chai')
 should = chai.should()
+expect = chai.expect
 sinon = require("sinon")
 modulePath = "../../../app/js/ChannelManager.js"
 SandboxedModule = require('sandboxed-module')
@@ -16,29 +17,78 @@ describe 'ChannelManager', ->
 	describe "subscribe", ->
 
 		describe "when there is no existing subscription for this redis client", ->
-			beforeEach ->
-				@rclient.subscribe = sinon.stub()
+			beforeEach (done) ->
+				@rclient.subscribe = sinon.stub().resolves()
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
+				setTimeout done
 
 			it "should subscribe to the redis channel", ->
 				@rclient.subscribe.calledWithExactly("applied-ops:1234567890abcdef").should.equal true
 
 		describe "when there is an existing subscription for this redis client", ->
-			beforeEach ->
-				@rclient.subscribe = sinon.stub()
+			beforeEach (done) ->
+				@rclient.subscribe = sinon.stub().resolves()
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
-				@rclient.subscribe = sinon.stub()  # discard the original stub
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
+				setTimeout done
 
-			it "should not subscribe to the redis channel", ->
-				@rclient.subscribe.called.should.equal false
+			it "should subscribe to the redis channel again", ->
+				@rclient.subscribe.callCount.should.equal 2
+
+		describe "when subscribe errors", ->
+			beforeEach (done) ->
+				@rclient.subscribe = sinon.stub()
+					.onFirstCall().rejects(new Error("some redis error"))
+					.onSecondCall().resolves()
+				p = @ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
+				p.then () ->
+					done(new Error('should not subscribe but fail'))
+				.catch (err) =>
+					err.message.should.equal "some redis error"
+					@ChannelManager.getClientMapEntry(@rclient).has("applied-ops:1234567890abcdef").should.equal false
+					@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
+					# subscribe is wrapped in Promise, delay other assertions
+					setTimeout done
+				return null
+
+			it "should have recorded the error", ->
+				expect(@metrics.inc.calledWithExactly("subscribe.failed.applied-ops")).to.equal(true)
+
+			it "should subscribe again", ->
+				@rclient.subscribe.callCount.should.equal 2
+
+			it "should cleanup", ->
+				@ChannelManager.getClientMapEntry(@rclient).has("applied-ops:1234567890abcdef").should.equal false
+
+		describe "when subscribe errors and the clientChannelMap entry was replaced", ->
+			beforeEach (done) ->
+				@rclient.subscribe = sinon.stub()
+					.onFirstCall().rejects(new Error("some redis error"))
+					.onSecondCall().resolves()
+				@first = @ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
+				# ignore error
+				@first.catch((()->))
+				expect(@ChannelManager.getClientMapEntry(@rclient).get("applied-ops:1234567890abcdef")).to.equal @first
+
+				@rclient.unsubscribe = sinon.stub().resolves()
+				@ChannelManager.unsubscribe @rclient, "applied-ops", "1234567890abcdef"
+				@second = @ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
+				# should get replaced immediately
+				expect(@ChannelManager.getClientMapEntry(@rclient).get("applied-ops:1234567890abcdef")).to.equal @second
+
+				# let the first subscribe error -> unsubscribe -> subscribe
+				setTimeout done
+
+			it "should cleanup the second subscribePromise", ->
+				expect(@ChannelManager.getClientMapEntry(@rclient).has("applied-ops:1234567890abcdef")).to.equal false
 
 		describe "when there is an existing subscription for another redis client but not this one", ->
-			beforeEach ->
-				@other_rclient.subscribe = sinon.stub()
+			beforeEach (done) ->
+				@other_rclient.subscribe = sinon.stub().resolves()
 				@ChannelManager.subscribe @other_rclient, "applied-ops", "1234567890abcdef"
-				@rclient.subscribe = sinon.stub()  # discard the original stub
+				@rclient.subscribe = sinon.stub().resolves()  # discard the original stub
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
+				setTimeout done
 
 			it "should subscribe to the redis channel on this redis client", ->
 				@rclient.subscribe.calledWithExactly("applied-ops:1234567890abcdef").should.equal true
@@ -46,30 +96,82 @@ describe 'ChannelManager', ->
 	describe "unsubscribe", ->
 
 		describe "when there is no existing subscription for this redis client", ->
-			beforeEach ->
-				@rclient.unsubscribe = sinon.stub()
+			beforeEach (done) ->
+				@rclient.unsubscribe = sinon.stub().resolves()
 				@ChannelManager.unsubscribe @rclient, "applied-ops", "1234567890abcdef"
+				setTimeout done
 
-			it "should not unsubscribe from the redis channel", ->
-				@rclient.unsubscribe.called.should.equal false
+			it "should unsubscribe from the redis channel", ->
+				@rclient.unsubscribe.called.should.equal true
 
 
 		describe "when there is an existing subscription for this another redis client but not this one", ->
-			beforeEach ->
-				@other_rclient.subscribe = sinon.stub()
-				@rclient.unsubscribe = sinon.stub()  
+			beforeEach (done) ->
+				@other_rclient.subscribe = sinon.stub().resolves()
+				@rclient.unsubscribe = sinon.stub().resolves()
 				@ChannelManager.subscribe @other_rclient, "applied-ops", "1234567890abcdef"
 				@ChannelManager.unsubscribe @rclient, "applied-ops", "1234567890abcdef"
+				setTimeout done
 
-			it "should not unsubscribe from the redis channel on this client", ->
-				@rclient.unsubscribe.called.should.equal false
+			it "should still unsubscribe from the redis channel on this client", ->
+				@rclient.unsubscribe.called.should.equal true
+
+		describe "when unsubscribe errors and completes", ->
+			beforeEach (done) ->
+				@rclient.subscribe = sinon.stub().resolves()
+				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
+				@rclient.unsubscribe = sinon.stub().rejects(new Error("some redis error"))
+				@ChannelManager.unsubscribe @rclient, "applied-ops", "1234567890abcdef"
+				setTimeout done
+				return null
+
+			it "should have cleaned up", ->
+				@ChannelManager.getClientMapEntry(@rclient).has("applied-ops:1234567890abcdef").should.equal false
+
+			it "should not error out when subscribing again", (done) ->
+				p = @ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
+				p.then () ->
+					done()
+				.catch done
+				return null
+
+		describe "when unsubscribe errors and another client subscribes at the same time", ->
+			beforeEach (done) ->
+				@rclient.subscribe = sinon.stub().resolves()
+				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
+				rejectSubscribe = undefined
+				@rclient.unsubscribe = () ->
+					return new Promise (resolve, reject) ->
+						rejectSubscribe = reject
+				@ChannelManager.unsubscribe @rclient, "applied-ops", "1234567890abcdef"
+
+				setTimeout () =>
+					# delay, actualUnsubscribe should not see the new subscribe request
+					@ChannelManager.subscribe(@rclient, "applied-ops", "1234567890abcdef")
+					.then () ->
+						setTimeout done
+					.catch done
+					setTimeout ->
+						# delay, rejectSubscribe is not defined immediately
+						rejectSubscribe(new Error("redis error"))
+				return null
+
+			it "should have recorded the error", ->
+				expect(@metrics.inc.calledWithExactly("unsubscribe.failed.applied-ops")).to.equal(true)
+
+			it "should have subscribed", ->
+				@rclient.subscribe.called.should.equal true
+
+			it "should have discarded the finished Promise", ->
+				@ChannelManager.getClientMapEntry(@rclient).has("applied-ops:1234567890abcdef").should.equal false
 
 		describe "when there is an existing subscription for this redis client", ->
-			beforeEach ->
-				@rclient.subscribe = sinon.stub()
-				@rclient.unsubscribe = sinon.stub()  
+			beforeEach (done) ->
+				@rclient.subscribe = sinon.stub().resolves()
+				@rclient.unsubscribe = sinon.stub().resolves()
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
 				@ChannelManager.unsubscribe @rclient, "applied-ops", "1234567890abcdef"
+				setTimeout done
 
 			it "should unsubscribe from the redis channel", ->
 				@rclient.unsubscribe.calledWithExactly("applied-ops:1234567890abcdef").should.equal true

--- a/test/unit/coffee/ChannelManagerTests.coffee
+++ b/test/unit/coffee/ChannelManagerTests.coffee
@@ -12,12 +12,12 @@ describe 'ChannelManager', ->
 			"settings-sharelatex": @settings = {}
 			"metrics-sharelatex": @metrics = {inc: sinon.stub(), summary: sinon.stub()}
 			"logger-sharelatex": @logger = { log: sinon.stub(), warn: sinon.stub(), error: sinon.stub() }
-
+	
 	describe "subscribe", ->
 
 		describe "when there is no existing subscription for this redis client", ->
 			beforeEach ->
-				@rclient.subscribe = sinon.stub().resolves()
+				@rclient.subscribe = sinon.stub()
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
 
 			it "should subscribe to the redis channel", ->
@@ -25,40 +25,19 @@ describe 'ChannelManager', ->
 
 		describe "when there is an existing subscription for this redis client", ->
 			beforeEach ->
-				@rclient.subscribe = sinon.stub().resolves()
+				@rclient.subscribe = sinon.stub()
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
-				@rclient.subscribe = sinon.stub().resolves()  # discard the original stub
+				@rclient.subscribe = sinon.stub()  # discard the original stub
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
 
 			it "should not subscribe to the redis channel", ->
 				@rclient.subscribe.called.should.equal false
 
-		describe "when subscribe errors", ->
-			# TODO(das7pad): rework after decaff -- our coffee-script version does not like async/await
-			beforeEach (done) ->
-				@rclient.subscribe = () ->
-					return new Promise (resolve, reject) ->
-						setTimeout((() -> reject(new Error("some redis error"))), 1)
-				p = @ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
-				@rclient.subscribe = sinon.stub().resolves()
-				p.then () ->
-					done(new Error('should not subscribe but fail'))
-				p.catch (err) =>
-					err.message.should.equal "some redis error"
-					@ChannelManager.getClientMapEntry(@rclient).has("applied-ops:1234567890abcdef").should.equal false
-					@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
-					done()
-				return null
-
-			it "should subscribe again", ->
-				@rclient.subscribe.called.should.equal true
-				@ChannelManager.getClientMapEntry(@rclient).has("applied-ops:1234567890abcdef").should.equal true
-
 		describe "when there is an existing subscription for another redis client but not this one", ->
 			beforeEach ->
-				@other_rclient.subscribe = sinon.stub().resolves()
+				@other_rclient.subscribe = sinon.stub()
 				@ChannelManager.subscribe @other_rclient, "applied-ops", "1234567890abcdef"
-				@rclient.subscribe = sinon.stub().resolves()  # discard the original stub
+				@rclient.subscribe = sinon.stub()  # discard the original stub
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
 
 			it "should subscribe to the redis channel on this redis client", ->
@@ -77,8 +56,8 @@ describe 'ChannelManager', ->
 
 		describe "when there is an existing subscription for this another redis client but not this one", ->
 			beforeEach ->
-				@other_rclient.subscribe = sinon.stub().resolves()
-				@rclient.unsubscribe = sinon.stub()
+				@other_rclient.subscribe = sinon.stub()
+				@rclient.unsubscribe = sinon.stub()  
 				@ChannelManager.subscribe @other_rclient, "applied-ops", "1234567890abcdef"
 				@ChannelManager.unsubscribe @rclient, "applied-ops", "1234567890abcdef"
 
@@ -87,8 +66,8 @@ describe 'ChannelManager', ->
 
 		describe "when there is an existing subscription for this redis client", ->
 			beforeEach ->
-				@rclient.subscribe = sinon.stub().resolves()
-				@rclient.unsubscribe = sinon.stub()
+				@rclient.subscribe = sinon.stub()
+				@rclient.unsubscribe = sinon.stub()  
 				@ChannelManager.subscribe @rclient, "applied-ops", "1234567890abcdef"
 				@ChannelManager.unsubscribe @rclient, "applied-ops", "1234567890abcdef"
 

--- a/test/unit/coffee/WebsocketControllerTests.coffee
+++ b/test/unit/coffee/WebsocketControllerTests.coffee
@@ -147,6 +147,19 @@ describe 'WebsocketController', ->
 			@WebsocketController.FLUSH_IF_EMPTY_DELAY = 0
 			tk.reset() # Allow setTimeout to work.
 
+		describe "when the client did not joined a project yet", ->
+			beforeEach (done) ->
+				@client.ol_context = {}
+				@WebsocketController.leaveProject @io, @client, done
+
+			it "should bail out when calling leaveProject", () ->
+				@WebsocketLoadBalancer.emitToRoom.called.should.equal false
+				@RoomManager.leaveProjectAndDocs.called.should.equal false
+				@ConnectedUsersManager.markUserAsDisconnected.called.should.equal false
+
+			it "should not inc any metric", () ->
+				@metrics.inc.called.should.equal false
+
 		describe "when the project is empty", ->
 			beforeEach (done) ->
 				@WebsocketController.leaveProject @io, @client, done
@@ -204,8 +217,8 @@ describe 'WebsocketController', ->
 					.calledWith(@project_id)
 					.should.equal false
 
-			it "should increment the leave-project metric", ->
-				@metrics.inc.calledWith("editor.leave-project").should.equal true
+			it "should not increment the leave-project metric", ->
+				@metrics.inc.calledWith("editor.leave-project").should.equal false
 
 		describe "when client has not joined a project", ->
 			beforeEach (done) ->
@@ -228,8 +241,8 @@ describe 'WebsocketController', ->
 					.calledWith(@project_id)
 					.should.equal false
 
-			it "should increment the leave-project metric", ->
-				@metrics.inc.calledWith("editor.leave-project").should.equal true
+			it "should not increment the leave-project metric", ->
+				@metrics.inc.calledWith("editor.leave-project").should.equal false
 
 	describe "joinDoc", ->
 		beforeEach ->

--- a/test/unit/coffee/WebsocketControllerTests.coffee
+++ b/test/unit/coffee/WebsocketControllerTests.coffee
@@ -130,7 +130,7 @@ describe 'WebsocketController', ->
 
 			it "should return an error", ->
 				@callback
-					.calledWith(new Error("subscribe failed"))
+					.calledWith(sinon.match({message: "subscribe failed"}))
 					.should.equal true
 				@callback.args[0][0].message.should.equal "subscribe failed"
 

--- a/test/unit/coffee/WebsocketControllerTests.coffee
+++ b/test/unit/coffee/WebsocketControllerTests.coffee
@@ -112,6 +112,28 @@ describe 'WebsocketController', ->
 			it "should not log an error", ->
 				@logger.error.called.should.equal false
 
+		describe "when the subscribe failed", ->
+			beforeEach ->
+				@client.id = "mock-client-id"
+				@project = {
+					name: "Test Project"
+					owner: {
+						_id: @owner_id = "mock-owner-id-123"
+					}
+				}
+				@privilegeLevel = "owner"
+				@ConnectedUsersManager.updateUserPosition = sinon.stub().callsArg(4)
+				@isRestrictedUser = true
+				@WebApiManager.joinProject = sinon.stub().callsArgWith(2, null, @project, @privilegeLevel, @isRestrictedUser)
+				@RoomManager.joinProject = sinon.stub().callsArgWith(2, new Error("subscribe failed"))
+				@WebsocketController.joinProject @client, @user, @project_id, @callback
+
+			it "should return an error", ->
+				@callback
+					.calledWith(new Error("subscribe failed"))
+					.should.equal true
+				@callback.args[0][0].message.should.equal "subscribe failed"
+
 	describe "leaveProject", ->
 		beforeEach ->
 			@DocumentUpdaterManager.flushProjectToMongoAndDelete = sinon.stub().callsArg(1)


### PR DESCRIPTION
### Description

master and v2 diverged quite a bit, so I had to revert a few changes and restore most of them after the merge.

- revert and restore the leaveProject bailout for clients that did not join previously, this change has a conflict with the client context gathering #135 
- drop sinon upgrade to v2 from v0 branch, the package lock changes conflict with v2 #136 
- revert whitespace changes from #137
- drop cleanup of subscribe failure https://github.com/overleaf/real-time/pull/130 in favor of #137 

The PubSubRace test suite is not stable with v2 and a followup PR will fix that.

#### Screenshots

broken PubSubRace build https://console.cloud.google.com/cloud-build/builds/604379c6-d5d0-4f49-b3b1-ed0f97989b72?project=overleaf-ops
rebuild passes: https://console.cloud.google.com/cloud-build/builds/24ed3e55-a8c4-43de-8f5e-80a5e28fbee2;step=2?project=overleaf-ops

#### Related Issues / PRs

#130
#135
#136 
#137 
https://github.com/overleaf/issues/issues/3002

### Review

In case that would help, I can add review comments with links to the change set of the original v0 PRs.

#### Potential Impact

High. Includes the changed redis pub/sub subscribe/unsubscribe logic of #137 

