### PR TITLE
[misc] stop processing requests as we detect a client disconnect

### DIFF
--- a/app/coffee/RoomManager.coffee
+++ b/app/coffee/RoomManager.coffee
@@ -70,8 +70,10 @@ module.exports = RoomManager =
       # Ignore any requests to leave when the client is not actually in the
       # room. This can happen if the client sends spurious leaveDoc requests
       # for old docs after a reconnection.
+      # It can also happen when we process a join and disconnect event in the
+      #  same event loop cycle.
       if !@_clientAlreadyInRoom(client, id)
-          logger.warn {client: client.id, entity, id}, "ignoring request from client to leave room it is not in"
+          logger.log {client: client.id, entity, id}, "ignoring request from client to leave room it is not in"
           return
       client.leave id
       @_clientsInRoom client, id, (afterCount) ->

--- a/app/coffee/WebsocketController.coffee
+++ b/app/coffee/WebsocketController.coffee
@@ -16,7 +16,7 @@ module.exports = WebsocketController =
 
 	joinProject: (client, user, project_id, callback = (error, project, privilegeLevel, protocolVersion) ->) ->
 		if not client.connected
-			metrics.inc('disconnected_join_project')
+			metrics.inc('editor.join-project.disconnected', 1, {status: 'immediately'})
 			return callback()
 
 		user_id = user?._id
@@ -25,7 +25,7 @@ module.exports = WebsocketController =
 		WebApiManager.joinProject project_id, user, (error, project, privilegeLevel, isRestrictedUser) ->
 			return callback(error) if error?
 			if not client.connected
-				metrics.inc('disconnected_join_project')
+				metrics.inc('editor.join-project.disconnected', 1, {status: 'after-web-api-call'})
 				return callback()
 
 			if !privilegeLevel or privilegeLevel == ""
@@ -84,7 +84,7 @@ module.exports = WebsocketController =
 
 	joinDoc: (client, doc_id, fromVersion = -1, options, callback = (error, doclines, version, ops, ranges) ->) ->
 			if not client.connected
-				metrics.inc('disconnected_join_doc')
+				metrics.inc('editor.join-doc.disconnected', 1, {status: 'immediately'})
 				return callback()
 
 			metrics.inc "editor.join-doc"
@@ -99,14 +99,14 @@ module.exports = WebsocketController =
 				RoomManager.joinDoc client, doc_id, (error) ->
 					return callback(error) if error?
 					if not client.connected
-						metrics.inc('disconnected_join_doc')
+						metrics.inc('editor.join-doc.disconnected', 1, {status: 'after-joining-room'})
 						# the client will not read the response anyways
 						return callback()
 
 					DocumentUpdaterManager.getDocument project_id, doc_id, fromVersion, (error, lines, version, ranges, ops) ->
 						return callback(error) if error?
 						if not client.connected
-							metrics.inc('disconnected_join_doc')
+							metrics.inc('editor.join-doc.disconnected', 1, {status: 'after-doc-updater-call'})
 							# the client will not read the response anyways
 							return callback()
 
@@ -247,7 +247,7 @@ module.exports = WebsocketController =
 						setTimeout () ->
 							if not client.connected
 								# skip the message broadcast, the client has moved on
-								return metrics.inc('disconnected_otUpdateError')
+								return metrics.inc('editor.doc-update.disconnected', 1, {status:'at-otUpdateError'})
 							client.emit "otUpdateError", message.error, message
 							client.disconnect()
 						, 100

--- a/test/acceptance/coffee/EarlyDisconnect.coffee
+++ b/test/acceptance/coffee/EarlyDisconnect.coffee
@@ -1,0 +1,160 @@
+async = require "async"
+{expect} = require("chai")
+
+RealTimeClient = require "./helpers/RealTimeClient"
+MockDocUpdaterServer = require "./helpers/MockDocUpdaterServer"
+MockWebServer = require "./helpers/MockWebServer"
+FixturesManager = require "./helpers/FixturesManager"
+
+settings = require "settings-sharelatex"
+redis = require "redis-sharelatex"
+rclient = redis.createClient(settings.redis.pubsub)
+rclientRT = redis.createClient(settings.redis.realtime)
+KeysRT = settings.redis.realtime.key_schema
+
+describe "EarlyDisconnect", ->
+	before (done) ->
+		MockDocUpdaterServer.run done
+
+	describe "when the client disconnects before joinProject completes", ->
+		before () ->
+			# slow down web-api requests to force the race condition
+			@actualWebAPIjoinProject = joinProject = MockWebServer.joinProject
+			MockWebServer.joinProject = (project_id, user_id, cb) ->
+				setTimeout () ->
+					joinProject(project_id, user_id, cb)
+				, 300
+
+		after () ->
+			MockWebServer.joinProject = @actualWebAPIjoinProject
+
+		beforeEach (done) ->
+			async.series [
+				(cb) =>
+					FixturesManager.setUpProject {
+						privilegeLevel: "owner"
+						project: {
+							name: "Test Project"
+						}
+					}, (e, {@project_id, @user_id}) => cb()
+
+				(cb) =>
+					@clientA = RealTimeClient.connect()
+					@clientA.on "connectionAccepted", cb
+
+				(cb) =>
+					@clientA.emit "joinProject", project_id: @project_id, (() ->)
+					# disconnect before joinProject completes
+					@clientA.on "disconnect", () -> cb()
+					@clientA.disconnect()
+
+				(cb) =>
+					# wait for joinDoc and subscribe
+					setTimeout cb, 500
+			], done
+
+		# we can force the race condition, there is no need to repeat too often
+		for attempt in Array.from(length: 5).map((_, i) -> i+1)
+			it "should not subscribe to the pub/sub channel anymore (race #{attempt})", (done) ->
+				rclient.pubsub 'CHANNELS', (err, resp) =>
+					return done(err) if err
+					expect(resp).to.not.include "editor-events:#{@project_id}"
+					done()
+				return null
+
+	describe "when the client disconnects before joinDoc completes", ->
+		beforeEach (done) ->
+			async.series [
+				(cb) =>
+					FixturesManager.setUpProject {
+						privilegeLevel: "owner"
+						project: {
+							name: "Test Project"
+						}
+					}, (e, {@project_id, @user_id}) => cb()
+
+				(cb) =>
+					@clientA = RealTimeClient.connect()
+					@clientA.on "connectionAccepted", cb
+
+				(cb) =>
+					@clientA.emit "joinProject", project_id: @project_id, (error, @project, @privilegeLevel, @protocolVersion) =>
+						cb(error)
+
+				(cb) =>
+					FixturesManager.setUpDoc @project_id, {@lines, @version, @ops}, (e, {@doc_id}) =>
+						cb(e)
+
+				(cb) =>
+					@clientA.emit "joinDoc", @doc_id, (() ->)
+					# disconnect before joinDoc completes
+					@clientA.on "disconnect", () -> cb()
+					@clientA.disconnect()
+
+				(cb) =>
+					# wait for subscribe and unsubscribe
+					setTimeout cb, 100
+			], done
+
+		# we can not force the race condition, so we have to try many times
+		for attempt in Array.from(length: 20).map((_, i) -> i+1)
+			it "should not subscribe to the pub/sub channels anymore (race #{attempt})", (done) ->
+				rclient.pubsub 'CHANNELS', (err, resp) =>
+					return done(err) if err
+					expect(resp).to.not.include "editor-events:#{@project_id}"
+
+					rclient.pubsub 'CHANNELS', (err, resp) =>
+						return done(err) if err
+						expect(resp).to.not.include "applied-ops:#{@doc_id}"
+						done()
+				return null
+
+	describe "when the client disconnects before clientTracking.updatePosition starts", ->
+		beforeEach (done) ->
+			async.series [
+				(cb) =>
+					FixturesManager.setUpProject {
+						privilegeLevel: "owner"
+						project: {
+							name: "Test Project"
+						}
+					}, (e, {@project_id, @user_id}) => cb()
+
+				(cb) =>
+					@clientA = RealTimeClient.connect()
+					@clientA.on "connectionAccepted", cb
+
+				(cb) =>
+					@clientA.emit "joinProject", project_id: @project_id, (error, @project, @privilegeLevel, @protocolVersion) =>
+						cb(error)
+
+				(cb) =>
+					FixturesManager.setUpDoc @project_id, {@lines, @version, @ops}, (e, {@doc_id}) =>
+						cb(e)
+
+				(cb) =>
+					@clientA.emit "joinDoc", @doc_id, cb
+
+				(cb) =>
+					@clientA.emit "clientTracking.updatePosition", {
+							row: 42
+							column: 36
+							doc_id: @doc_id
+						}, (() ->)
+					# disconnect before updateClientPosition completes
+					@clientA.on "disconnect", () -> cb()
+					@clientA.disconnect()
+
+				(cb) =>
+					# wait for updateClientPosition
+					setTimeout cb, 100
+			], done
+
+		# we can not force the race condition, so we have to try many times
+		for attempt in Array.from(length: 20).map((_, i) -> i+1)
+			it "should not show the client as connected (race #{attempt})", (done) ->
+				rclientRT.smembers KeysRT.clientsInProject({project_id: @project_id}), (err, results) ->
+					return done(err) if err
+					expect(results).to.deep.equal([])
+					done()
+				return null

--- a/test/unit/coffee/WebsocketControllerTests.coffee
+++ b/test/unit/coffee/WebsocketControllerTests.coffee
@@ -20,6 +20,7 @@ describe 'WebsocketController', ->
 		}
 		@callback = sinon.stub()
 		@client =
+			connected: true
 			id: @client_id = "mock-client-id-123"
 			ol_context: {}
 			join: sinon.stub()
@@ -133,6 +134,35 @@ describe 'WebsocketController', ->
 					.calledWith(sinon.match({message: "subscribe failed"}))
 					.should.equal true
 				@callback.args[0][0].message.should.equal "subscribe failed"
+
+		describe "when the client has disconnected", ->
+			beforeEach ->
+				@client.connected = false
+				@WebApiManager.joinProject = sinon.stub().callsArg(2)
+				@WebsocketController.joinProject @client, @user, @project_id, @callback
+
+			it "should not call WebApiManager.joinProject", ->
+				expect(@WebApiManager.joinProject.called).to.equal(false)
+
+			it "should call the callback with no details", ->
+				expect(@callback.args[0]).to.deep.equal []
+
+			it "should increment the disconnected_join_project metric", ->
+				expect(@metrics.inc.calledWith("disconnected_join_project")).to.equal(true)
+
+		describe "when the client disconnects while WebApiManager.joinProject is running", ->
+			beforeEach ->
+				@WebApiManager.joinProject = (project, user, cb) =>
+					@client.connected = false
+					cb(null, @project, @privilegeLevel, @isRestrictedUser)
+
+				@WebsocketController.joinProject @client, @user, @project_id, @callback
+
+			it "should call the callback with no details", ->
+				expect(@callback.args[0]).to.deep.equal []
+
+			it "should increment the disconnected_join_project metric", ->
+				expect(@metrics.inc.calledWith("disconnected_join_project")).to.equal(true)
 
 	describe "leaveProject", ->
 		beforeEach ->
@@ -365,6 +395,51 @@ describe 'WebsocketController', ->
 				ranges = @callback.args[0][4]
 				expect(ranges.comments).to.deep.equal []
 
+		describe "when the client has disconnected", ->
+			beforeEach ->
+				@client.connected = false
+				@WebsocketController.joinDoc @client, @doc_id, -1, @options, @callback
+
+			it "should call the callback with no details", ->
+				expect(@callback.args[0]).to.deep.equal([])
+
+			it "should increment the disconnected_join_doc metric", ->
+				expect(@metrics.inc.calledWith("disconnected_join_doc")).to.equal(true)
+
+			it "should not get the document", ->
+				expect(@DocumentUpdaterManager.getDocument.called).to.equal(false)
+
+		describe "when the client disconnects while RoomManager.joinDoc is running", ->
+			beforeEach ->
+				@RoomManager.joinDoc = (client, doc_id, cb) =>
+					@client.connected = false
+					cb()
+
+				@WebsocketController.joinDoc @client, @doc_id, -1, @options, @callback
+
+			it "should call the callback with no details", ->
+				expect(@callback.args[0]).to.deep.equal([])
+
+			it "should increment the disconnected_join_doc metric", ->
+				expect(@metrics.inc.calledWith("disconnected_join_doc")).to.equal(true)
+
+			it "should not get the document", ->
+				expect(@DocumentUpdaterManager.getDocument.called).to.equal(false)
+
+		describe "when the client disconnects while DocumentUpdaterManager.getDocument is running", ->
+			beforeEach ->
+				@DocumentUpdaterManager.getDocument = (project_id, doc_id, fromVersion, callback) =>
+					@client.connected = false
+					callback(null, @doc_lines, @version, @ranges, @ops)
+
+				@WebsocketController.joinDoc @client, @doc_id, -1, @options, @callback
+
+			it "should call the callback with no details", ->
+				expect(@callback.args[0]).to.deep.equal []
+
+			it "should increment the disconnected_join_doc metric", ->
+				expect(@metrics.inc.calledWith("disconnected_join_doc")).to.equal(true)
+
 	describe "leaveDoc", ->
 		beforeEach ->
 			@doc_id = "doc-id-123"
@@ -443,6 +518,18 @@ describe 'WebsocketController', ->
 				@ConnectedUsersManager.getConnectedUsers
 					.called
 					.should.equal false
+
+		describe "when the client has disconnected", ->
+			beforeEach ->
+				@client.connected = false
+				@AuthorizationManager.assertClientCanViewProject = sinon.stub()
+				@WebsocketController.getConnectedUsers @client, @callback
+
+			it "should call the callback with no details", ->
+				expect(@callback.args[0]).to.deep.equal([])
+
+			it "should not check permissions", ->
+				expect(@AuthorizationManager.assertClientCanViewProject.called).to.equal(false)
 
 	describe "updateClientPosition", ->
 		beforeEach ->
@@ -618,6 +705,18 @@ describe 'WebsocketController', ->
 				@ConnectedUsersManager.updateUserPosition.called.should.equal false
 				done()
 
+		describe "when the client has disconnected", ->
+			beforeEach ->
+				@client.connected = false
+				@AuthorizationManager.assertClientCanViewProjectAndDoc = sinon.stub()
+				@WebsocketController.updateClientPosition @client, @update, @callback
+
+			it "should call the callback with no details", ->
+				expect(@callback.args[0]).to.deep.equal([])
+
+			it "should not check permissions", ->
+				expect(@AuthorizationManager.assertClientCanViewProjectAndDoc.called).to.equal(false)
+
 	describe "applyOtUpdate", ->
 		beforeEach ->
 			@update = {op: {p: 12, t: "foo"}}
@@ -691,7 +790,7 @@ describe 'WebsocketController', ->
 				@WebsocketController.applyOtUpdate @client, @doc_id, @update, @callback
 				setTimeout ->
 					done()
-				, 201
+				, 1
 
 			it "should call the callback with no error", ->
 				@callback.called.should.equal true
@@ -703,11 +802,29 @@ describe 'WebsocketController', ->
 					@user_id, @project_id, @doc_id, updateSize: 7372835
 				}, 'update is too large']
 
-			it "should send an otUpdateError the client", ->
-				@client.emit.calledWith('otUpdateError').should.equal true
+			describe "after 100ms", ->
+				beforeEach (done) ->
+					setTimeout done, 100
 
-			it "should disconnect the client", ->
-				@client.disconnect.called.should.equal true
+				it "should send an otUpdateError the client", ->
+					@client.emit.calledWith('otUpdateError').should.equal true
+
+				it "should disconnect the client", ->
+					@client.disconnect.called.should.equal true
+
+			describe "when the client disconnects during the next 100ms", ->
+				beforeEach (done) ->
+					@client.connected = false
+					setTimeout done, 100
+
+				it "should not send an otUpdateError the client", ->
+					@client.emit.calledWith('otUpdateError').should.equal false
+
+				it "should not disconnect the client", ->
+					@client.disconnect.called.should.equal false
+
+				it "should increment the disconnected_otUpdateError metric", ->
+					expect(@metrics.inc.calledWith("disconnected_otUpdateError")).to.equal(true)
 
 	describe "_assertClientCanApplyUpdate", ->
 		beforeEach ->

--- a/test/unit/coffee/WebsocketControllerTests.coffee
+++ b/test/unit/coffee/WebsocketControllerTests.coffee
@@ -147,8 +147,8 @@ describe 'WebsocketController', ->
 			it "should call the callback with no details", ->
 				expect(@callback.args[0]).to.deep.equal []
 
-			it "should increment the disconnected_join_project metric", ->
-				expect(@metrics.inc.calledWith("disconnected_join_project")).to.equal(true)
+			it "should increment the editor.join-project.disconnected metric with a status", ->
+				expect(@metrics.inc.calledWith('editor.join-project.disconnected', 1, {status: 'immediately'})).to.equal(true)
 
 		describe "when the client disconnects while WebApiManager.joinProject is running", ->
 			beforeEach ->
@@ -161,8 +161,8 @@ describe 'WebsocketController', ->
 			it "should call the callback with no details", ->
 				expect(@callback.args[0]).to.deep.equal []
 
-			it "should increment the disconnected_join_project metric", ->
-				expect(@metrics.inc.calledWith("disconnected_join_project")).to.equal(true)
+			it "should increment the editor.join-project.disconnected metric with a status", ->
+				expect(@metrics.inc.calledWith('editor.join-project.disconnected', 1, {status: 'after-web-api-call'})).to.equal(true)
 
 	describe "leaveProject", ->
 		beforeEach ->
@@ -403,8 +403,8 @@ describe 'WebsocketController', ->
 			it "should call the callback with no details", ->
 				expect(@callback.args[0]).to.deep.equal([])
 
-			it "should increment the disconnected_join_doc metric", ->
-				expect(@metrics.inc.calledWith("disconnected_join_doc")).to.equal(true)
+			it "should increment the editor.join-doc.disconnected metric with a status", ->
+				expect(@metrics.inc.calledWith('editor.join-doc.disconnected', 1, {status: 'immediately'})).to.equal(true)
 
 			it "should not get the document", ->
 				expect(@DocumentUpdaterManager.getDocument.called).to.equal(false)
@@ -420,8 +420,8 @@ describe 'WebsocketController', ->
 			it "should call the callback with no details", ->
 				expect(@callback.args[0]).to.deep.equal([])
 
-			it "should increment the disconnected_join_doc metric", ->
-				expect(@metrics.inc.calledWith("disconnected_join_doc")).to.equal(true)
+			it "should increment the editor.join-doc.disconnected metric with a status", ->
+				expect(@metrics.inc.calledWith('editor.join-doc.disconnected', 1, {status: 'after-joining-room'})).to.equal(true)
 
 			it "should not get the document", ->
 				expect(@DocumentUpdaterManager.getDocument.called).to.equal(false)
@@ -437,8 +437,8 @@ describe 'WebsocketController', ->
 			it "should call the callback with no details", ->
 				expect(@callback.args[0]).to.deep.equal []
 
-			it "should increment the disconnected_join_doc metric", ->
-				expect(@metrics.inc.calledWith("disconnected_join_doc")).to.equal(true)
+			it "should increment the editor.join-doc.disconnected metric with a status", ->
+				expect(@metrics.inc.calledWith('editor.join-doc.disconnected', 1, {status: 'after-doc-updater-call'})).to.equal(true)
 
 	describe "leaveDoc", ->
 		beforeEach ->
@@ -823,8 +823,8 @@ describe 'WebsocketController', ->
 				it "should not disconnect the client", ->
 					@client.disconnect.called.should.equal false
 
-				it "should increment the disconnected_otUpdateError metric", ->
-					expect(@metrics.inc.calledWith("disconnected_otUpdateError")).to.equal(true)
+				it "should increment the editor.doc-update.disconnected metric with a status", ->
+					expect(@metrics.inc.calledWith('editor.doc-update.disconnected', 1, {status:'at-otUpdateError'})).to.equal(true)
 
 	describe "_assertClientCanApplyUpdate", ->
 		beforeEach ->


### PR DESCRIPTION
### Description

Chained onto https://github.com/overleaf/real-time/pull/139 which merges v0 (including a pub/sub race test suite)

This PR fixes racing join requests and disconnect events. The processing of disconnect events skips a `process.nextTick` call (2 vs 3 calls) and hence we will process disconnect before a join request (or other rpc call).

- joinProject
   -  bails out at start, after web api call
   - previous impact: could leave dangling pub/sub subscribes

- joinDoc

  - bails out at start, after redis pub/sub join (1), after doc-updater call
  - previous impact: could leave dangling pub/sub subscribes, e.g. see [this failed build](https://console.cloud.google.com/cloud-build/builds/604379c6-d5d0-4f49-b3b1-ed0f97989b72;step=2?project=overleaf-ops)

- updateClientPosition
   - bails out at start
   - previous impact: could create ghost clients

- getConnectedUsers
   - bails out at start
   - previous impact: multiple useless redis calls

- applyOtUpdate

   - I chose to process the update anyways, even tho we can not signal a processing error back.
   - bail out when notifying the client about a too large update with a 100ms delay
   - previous impact: useless processing on dead client

(1) this does not need any extra handling: we join the socket.io room before calling into redis, hence the disconnect will pick up the existing socket.io room membership and leave it (it will wait for subscribe to complete first #137).

#### Screenshots

Race condition flagged in CI https://console.cloud.google.com/cloud-build/builds/604379c6-d5d0-4f49-b3b1-ed0f97989b72;step=2?project=overleaf-ops

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3002

#### Potential Impact

High, join requests could fail for unstable connections. We [create a new socket.io connection/client per (re)connect ](https://github.com/overleaf/web/blob/4c252fb81f495204136d32e5fe3730884518d746/frontend/js/ide/connection/SocketIoShim.js#L140-L163) and the [reconnect feature of socket.io is turned off](https://github.com/overleaf/web/blob/4c252fb81f495204136d32e5fe3730884518d746/frontend/js/ide/connection/ConnectionManager.js#L131), so this fear is not warranted.

#### Manual Testing Performed

- full coverage via unit tests
- new acceptance test suite which covers different races (joinProject, joinDoc, updateClientPosition)
  Given that we can not force the joinDoc and updateClientPosition race condition, I retry the tests multiple times, which increases the test suite run time by about 10s.
- there is an existing PubSubRace test suite 

#### Metrics and Monitoring

`disconnected_join_project`
`disconnected_join_doc`
`disconnected_otUpdateError`
