### PR TITLE
[backport] 140: stop processing requests as we detect a client disconnect

### DIFF
--- a/app/coffee/RoomManager.coffee
+++ b/app/coffee/RoomManager.coffee
@@ -71,8 +71,10 @@ module.exports = RoomManager =
         # Ignore any requests to leave when the client is not actually in the
         # room. This can happen if the client sends spurious leaveDoc requests
         # for old docs after a reconnection.
+        # This can now happen all the time, as we skip the join for clients that
+        #  disconnect before joinProject/joinDoc completed.
         if !@_clientAlreadyInRoom(client, id)
-            logger.warn {client: client.id, entity, id}, "ignoring request from client to leave room it is not in"
+            logger.log {client: client.id, entity, id}, "ignoring request from client to leave room it is not in"
             return
         client.leave id
         afterCount = @_clientsInRoom(client, id)

--- a/app/coffee/WebsocketController.coffee
+++ b/app/coffee/WebsocketController.coffee
@@ -17,7 +17,7 @@ module.exports = WebsocketController =
 
 	joinProject: (client, user, project_id, callback = (error, project, privilegeLevel, protocolVersion) ->) ->
 		if client.disconnected
-			metrics.inc('disconnected_join_project')
+			metrics.inc('editor.join-project.disconnected', 1, {status: 'immediately'})
 			return callback()
 
 		user_id = user?._id
@@ -26,7 +26,7 @@ module.exports = WebsocketController =
 		WebApiManager.joinProject project_id, user, (error, project, privilegeLevel, isRestrictedUser) ->
 			return callback(error) if error?
 			if client.disconnected
-				metrics.inc('disconnected_join_project')
+				metrics.inc('editor.join-project.disconnected', 1, {status: 'after-web-api-call'})
 				return callback()
 
 			if !privilegeLevel or privilegeLevel == ""
@@ -85,7 +85,7 @@ module.exports = WebsocketController =
 
 	joinDoc: (client, doc_id, fromVersion = -1, options, callback = (error, doclines, version, ops, ranges) ->) ->
 		if client.disconnected
-				metrics.inc('disconnected_join_doc')
+				metrics.inc('editor.join-doc.disconnected', 1, {status: 'immediately'})
 				return callback()
 
 		metrics.inc "editor.join-doc"
@@ -101,14 +101,14 @@ module.exports = WebsocketController =
 				RoomManager.joinDoc client, doc_id, (error) ->
 					return callback(error) if error?
 					if client.disconnected
-						metrics.inc('disconnected_join_doc')
+						metrics.inc('editor.join-doc.disconnected', 1, {status: 'after-joining-room'})
 						# the client will not read the response anyways
 						return callback()
 
 					DocumentUpdaterManager.getDocument project_id, doc_id, fromVersion, (error, lines, version, ranges, ops) ->
 						return callback(error) if error?
 						if client.disconnected
-							metrics.inc('disconnected_join_doc')
+							metrics.inc('editor.join-doc.disconnected', 1, {status: 'after-doc-updater-call'})
 							# the client will not read the response anyways
 							return callback()
 
@@ -255,7 +255,7 @@ module.exports = WebsocketController =
 						setTimeout () ->
 							if client.disconnected
 								# skip the message broadcast, the client has moved on
-								return metrics.inc('disconnected_otUpdateError')
+								return metrics.inc('editor.doc-update.disconnected', 1, {status:'at-otUpdateError'})
 							client.emit "otUpdateError", message.error, message
 							client.disconnect()
 						, 100

--- a/app/coffee/WebsocketController.coffee
+++ b/app/coffee/WebsocketController.coffee
@@ -16,11 +16,18 @@ module.exports = WebsocketController =
 	PROTOCOL_VERSION: 2
 
 	joinProject: (client, user, project_id, callback = (error, project, privilegeLevel, protocolVersion) ->) ->
+		if client.disconnected
+			metrics.inc('disconnected_join_project')
+			return callback()
+
 		user_id = user?._id
 		logger.log {user_id, project_id, client_id: client.id}, "user joining project"
 		metrics.inc "editor.join-project"
 		WebApiManager.joinProject project_id, user, (error, project, privilegeLevel, isRestrictedUser) ->
 			return callback(error) if error?
+			if client.disconnected
+				metrics.inc('disconnected_join_project')
+				return callback()
 
 			if !privilegeLevel or privilegeLevel == ""
 				err = new Error("not authorized")
@@ -77,6 +84,10 @@ module.exports = WebsocketController =
 			, WebsocketController.FLUSH_IF_EMPTY_DELAY
 
 	joinDoc: (client, doc_id, fromVersion = -1, options, callback = (error, doclines, version, ops, ranges) ->) ->
+		if client.disconnected
+				metrics.inc('disconnected_join_doc')
+				return callback()
+
 		metrics.inc "editor.join-doc"
 		Utils.getClientAttributes client, ["project_id", "user_id", "is_restricted_user"], (error, {project_id, user_id, is_restricted_user}) ->
 			return callback(error) if error?
@@ -89,8 +100,17 @@ module.exports = WebsocketController =
 				# doc to the client, so that no events are missed.
 				RoomManager.joinDoc client, doc_id, (error) ->
 					return callback(error) if error?
+					if client.disconnected
+						metrics.inc('disconnected_join_doc')
+						# the client will not read the response anyways
+						return callback()
+
 					DocumentUpdaterManager.getDocument project_id, doc_id, fromVersion, (error, lines, version, ranges, ops) ->
 						return callback(error) if error?
+						if client.disconnected
+							metrics.inc('disconnected_join_doc')
+							# the client will not read the response anyways
+							return callback()
 
 						if is_restricted_user and ranges?.comments?
 							ranges.comments = []
@@ -122,6 +142,7 @@ module.exports = WebsocketController =
 						callback null, escapedLines, version, ops, ranges
 
 	leaveDoc: (client, doc_id, callback = (error) ->) ->
+		# client may have disconnected, but we have to cleanup internal state.
 		metrics.inc "editor.leave-doc"
 		Utils.getClientAttributes client, ["project_id", "user_id"], (error, {project_id, user_id}) ->
 			logger.log {user_id, project_id, doc_id, client_id: client.id}, "client leaving doc"
@@ -132,6 +153,10 @@ module.exports = WebsocketController =
 			## AuthorizationManager.removeAccessToDoc client, doc_id
 			callback()
 	updateClientPosition: (client, cursorData, callback = (error) ->) ->
+		if client.disconnected
+				# do not create a ghost entry in redis
+				return callback()
+
 		metrics.inc "editor.update-client-position", 0.1
 		Utils.getClientAttributes client, [
 			"project_id", "first_name", "last_name", "email", "user_id"
@@ -173,6 +198,10 @@ module.exports = WebsocketController =
 
 	CLIENT_REFRESH_DELAY: 1000
 	getConnectedUsers: (client, callback = (error, users) ->) ->
+		if client.disconnected
+				# they are not interested anymore, skip the redis lookups
+				return callback()
+
 		metrics.inc "editor.get-connected-users"
 		Utils.getClientAttributes client, ["project_id", "user_id", "is_restricted_user"], (error, clientAttributes) ->
 			return callback(error) if error?
@@ -192,6 +221,7 @@ module.exports = WebsocketController =
 				, WebsocketController.CLIENT_REFRESH_DELAY
 
 	applyOtUpdate: (client, doc_id, update, callback = (error) ->) ->
+		# client may have disconnected, but we can submit their update to doc-updater anyways.
 		Utils.getClientAttributes client, ["user_id", "project_id"], (error, {user_id, project_id}) ->
 			return callback(error) if error?
 			return callback(new Error("no project_id found on client")) if !project_id?
@@ -223,6 +253,9 @@ module.exports = WebsocketController =
 						# trigger an out-of-sync error
 						message = {project_id, doc_id, error: "update is too large"}
 						setTimeout () ->
+							if client.disconnected
+								# skip the message broadcast, the client has moved on
+								return metrics.inc('disconnected_otUpdateError')
 							client.emit "otUpdateError", message.error, message
 							client.disconnect()
 						, 100

--- a/test/acceptance/coffee/EarlyDisconnect.coffee
+++ b/test/acceptance/coffee/EarlyDisconnect.coffee
@@ -1,0 +1,160 @@
+async = require "async"
+{expect} = require("chai")
+
+RealTimeClient = require "./helpers/RealTimeClient"
+MockDocUpdaterServer = require "./helpers/MockDocUpdaterServer"
+MockWebServer = require "./helpers/MockWebServer"
+FixturesManager = require "./helpers/FixturesManager"
+
+settings = require "settings-sharelatex"
+redis = require "redis-sharelatex"
+rclient = redis.createClient(settings.redis.pubsub)
+rclientRT = redis.createClient(settings.redis.realtime)
+KeysRT = settings.redis.realtime.key_schema
+
+describe "EarlyDisconnect", ->
+	before (done) ->
+		MockDocUpdaterServer.run done
+
+	describe "when the client disconnects before joinProject completes", ->
+		before () ->
+			# slow down web-api requests to force the race condition
+			@actualWebAPIjoinProject = joinProject = MockWebServer.joinProject
+			MockWebServer.joinProject = (project_id, user_id, cb) ->
+				setTimeout () ->
+					joinProject(project_id, user_id, cb)
+				, 300
+
+		after () ->
+			MockWebServer.joinProject = @actualWebAPIjoinProject
+
+		beforeEach (done) ->
+			async.series [
+				(cb) =>
+					FixturesManager.setUpProject {
+						privilegeLevel: "owner"
+						project: {
+							name: "Test Project"
+						}
+					}, (e, {@project_id, @user_id}) => cb()
+
+				(cb) =>
+					@clientA = RealTimeClient.connect()
+					@clientA.on "connectionAccepted", cb
+
+				(cb) =>
+					@clientA.emit "joinProject", project_id: @project_id, (() ->)
+					# disconnect before joinProject completes
+					@clientA.on "disconnect", () -> cb()
+					@clientA.disconnect()
+
+				(cb) =>
+					# wait for joinDoc and subscribe
+					setTimeout cb, 500
+			], done
+
+		# we can force the race condition, there is no need to repeat too often
+		for attempt in Array.from(length: 5).map((_, i) -> i+1)
+			it "should not subscribe to the pub/sub channel anymore (race #{attempt})", (done) ->
+				rclient.pubsub 'CHANNELS', (err, resp) =>
+					return done(err) if err
+					expect(resp).to.not.include "editor-events:#{@project_id}"
+					done()
+				return null
+
+	describe "when the client disconnects before joinDoc completes", ->
+		beforeEach (done) ->
+			async.series [
+				(cb) =>
+					FixturesManager.setUpProject {
+						privilegeLevel: "owner"
+						project: {
+							name: "Test Project"
+						}
+					}, (e, {@project_id, @user_id}) => cb()
+
+				(cb) =>
+					@clientA = RealTimeClient.connect()
+					@clientA.on "connectionAccepted", cb
+
+				(cb) =>
+					@clientA.emit "joinProject", project_id: @project_id, (error, @project, @privilegeLevel, @protocolVersion) =>
+						cb(error)
+
+				(cb) =>
+					FixturesManager.setUpDoc @project_id, {@lines, @version, @ops}, (e, {@doc_id}) =>
+						cb(e)
+
+				(cb) =>
+					@clientA.emit "joinDoc", @doc_id, (() ->)
+					# disconnect before joinDoc completes
+					@clientA.on "disconnect", () -> cb()
+					@clientA.disconnect()
+
+				(cb) =>
+					# wait for subscribe and unsubscribe
+					setTimeout cb, 100
+			], done
+
+		# we can not force the race condition, so we have to try many times
+		for attempt in Array.from(length: 20).map((_, i) -> i+1)
+			it "should not subscribe to the pub/sub channels anymore (race #{attempt})", (done) ->
+				rclient.pubsub 'CHANNELS', (err, resp) =>
+					return done(err) if err
+					expect(resp).to.not.include "editor-events:#{@project_id}"
+
+					rclient.pubsub 'CHANNELS', (err, resp) =>
+						return done(err) if err
+						expect(resp).to.not.include "applied-ops:#{@doc_id}"
+						done()
+				return null
+
+	describe "when the client disconnects before clientTracking.updatePosition starts", ->
+		beforeEach (done) ->
+			async.series [
+				(cb) =>
+					FixturesManager.setUpProject {
+						privilegeLevel: "owner"
+						project: {
+							name: "Test Project"
+						}
+					}, (e, {@project_id, @user_id}) => cb()
+
+				(cb) =>
+					@clientA = RealTimeClient.connect()
+					@clientA.on "connectionAccepted", cb
+
+				(cb) =>
+					@clientA.emit "joinProject", project_id: @project_id, (error, @project, @privilegeLevel, @protocolVersion) =>
+						cb(error)
+
+				(cb) =>
+					FixturesManager.setUpDoc @project_id, {@lines, @version, @ops}, (e, {@doc_id}) =>
+						cb(e)
+
+				(cb) =>
+					@clientA.emit "joinDoc", @doc_id, cb
+
+				(cb) =>
+					@clientA.emit "clientTracking.updatePosition", {
+							row: 42
+							column: 36
+							doc_id: @doc_id
+						}, (() ->)
+					# disconnect before updateClientPosition completes
+					@clientA.on "disconnect", () -> cb()
+					@clientA.disconnect()
+
+				(cb) =>
+					# wait for updateClientPosition
+					setTimeout cb, 100
+			], done
+
+		# we can not force the race condition, so we have to try many times
+		for attempt in Array.from(length: 20).map((_, i) -> i+1)
+			it "should not show the client as connected (race #{attempt})", (done) ->
+				rclientRT.smembers KeysRT.clientsInProject({project_id: @project_id}), (err, results) ->
+					return done(err) if err
+					expect(results).to.deep.equal([])
+					done()
+				return null

--- a/test/acceptance/coffee/LeaveDocTests.coffee
+++ b/test/acceptance/coffee/LeaveDocTests.coffee
@@ -17,12 +17,14 @@ describe "leaveDoc", ->
 		@ops = ["mock", "doc", "ops"]
 		sinon.spy(logger, "error")
 		sinon.spy(logger, "warn")
+		sinon.spy(logger, "log")
 		@other_doc_id = FixturesManager.getRandomId()
 	
 	after ->
 		logger.error.restore() # remove the spy
 		logger.warn.restore()
-			
+		logger.log.restore()
+
 	describe "when joined to a doc", ->
 		beforeEach (done) ->
 			async.series [
@@ -80,5 +82,5 @@ describe "leaveDoc", ->
 					throw error if error?
 					done()
 
-			it "should trigger a warning only", ->
-				sinon.assert.calledWith(logger.warn, sinon.match.any, "ignoring request from client to leave room it is not in")
+			it "should trigger a low level message only", ->
+				sinon.assert.calledWith(logger.log, sinon.match.any, "ignoring request from client to leave room it is not in")

--- a/test/unit/coffee/WebsocketControllerTests.coffee
+++ b/test/unit/coffee/WebsocketControllerTests.coffee
@@ -160,8 +160,8 @@ describe 'WebsocketController', ->
 			it "should call the callback with no details", ->
 				expect(@callback.args[0]).to.deep.equal []
 
-			it "should increment the disconnected_join_project metric", ->
-				expect(@metrics.inc.calledWith("disconnected_join_project")).to.equal(true)
+			it "should increment the editor.join-project.disconnected metric with a status", ->
+				expect(@metrics.inc.calledWith('editor.join-project.disconnected', 1, {status: 'immediately'})).to.equal(true)
 
 		describe "when the client disconnects while WebApiManager.joinProject is running", ->
 			beforeEach ->
@@ -174,8 +174,8 @@ describe 'WebsocketController', ->
 			it "should call the callback with no details", ->
 				expect(@callback.args[0]).to.deep.equal []
 
-			it "should increment the disconnected_join_project metric", ->
-				expect(@metrics.inc.calledWith("disconnected_join_project")).to.equal(true)
+			it "should increment the editor.join-project.disconnected metric with a status", ->
+				expect(@metrics.inc.calledWith('editor.join-project.disconnected', 1, {status: 'after-web-api-call'})).to.equal(true)
 
 	describe "leaveProject", ->
 		beforeEach ->
@@ -422,8 +422,8 @@ describe 'WebsocketController', ->
 			it "should call the callback with no details", ->
 				expect(@callback.args[0]).to.deep.equal([])
 
-			it "should increment the disconnected_join_doc metric", ->
-				expect(@metrics.inc.calledWith("disconnected_join_doc")).to.equal(true)
+			it "should increment the editor.join-doc.disconnected metric with a status", ->
+				expect(@metrics.inc.calledWith('editor.join-doc.disconnected', 1, {status: 'immediately'})).to.equal(true)
 
 			it "should not get the document", ->
 				expect(@DocumentUpdaterManager.getDocument.called).to.equal(false)
@@ -439,8 +439,8 @@ describe 'WebsocketController', ->
 			it "should call the callback with no details", ->
 				expect(@callback.args[0]).to.deep.equal([])
 
-			it "should increment the disconnected_join_doc metric", ->
-				expect(@metrics.inc.calledWith("disconnected_join_doc")).to.equal(true)
+			it "should increment the editor.join-doc.disconnected metric with a status", ->
+				expect(@metrics.inc.calledWith('editor.join-doc.disconnected', 1, {status: 'after-joining-room'})).to.equal(true)
 
 			it "should not get the document", ->
 				expect(@DocumentUpdaterManager.getDocument.called).to.equal(false)
@@ -456,8 +456,8 @@ describe 'WebsocketController', ->
 			it "should call the callback with no details", ->
 				expect(@callback.args[0]).to.deep.equal []
 
-			it "should increment the disconnected_join_doc metric", ->
-				expect(@metrics.inc.calledWith("disconnected_join_doc")).to.equal(true)
+			it "should increment the editor.join-doc.disconnected metric with a status", ->
+				expect(@metrics.inc.calledWith('editor.join-doc.disconnected', 1, {status: 'after-doc-updater-call'})).to.equal(true)
 
 	describe "leaveDoc", ->
 		beforeEach ->
@@ -847,8 +847,8 @@ describe 'WebsocketController', ->
 				it "should not disconnect the client", ->
 					@client.disconnect.called.should.equal false
 
-				it "should increment the disconnected_otUpdateError metric", ->
-					expect(@metrics.inc.calledWith("disconnected_otUpdateError")).to.equal(true)
+				it "should increment the editor.doc-update.disconnected metric with a status", ->
+					expect(@metrics.inc.calledWith('editor.doc-update.disconnected', 1, {status:'at-otUpdateError'})).to.equal(true)
 
 	describe "_assertClientCanApplyUpdate", ->
 		beforeEach ->


### PR DESCRIPTION
#### Description

Backport https://github.com/overleaf/real-time/pull/140

#### Related Issues / PRs

https://github.com/overleaf/real-time/pull/140

### Review

The interfaces for v0 and v2 differ, in the the connected state is stored on the lower level in v0 `client.socket.connected`.
But v0 also expose the state inverted on top-level via `client.disconnected`.
https://github.com/socketio/socket.io/blob/41b9a7e45d62ead3b4b36dc38cc8c03882ecc577/lib/socket.js#L151-L156


Some indents are off, but decaff/prettier will take care of that eventually.
