### PR TITLE
[misc] downgrade logging when running tests

### DIFF
--- a/test/acceptance/coffee/helpers/RealtimeServer.coffee
+++ b/test/acceptance/coffee/helpers/RealtimeServer.coffee
@@ -1,5 +1,4 @@
 app = require('../../../../app')
-require("logger-sharelatex").logger.level("info")
 logger = require("logger-sharelatex")
 Settings = require("settings-sharelatex")
 

--- a/test/unit/coffee/ChannelManagerTests.coffee
+++ b/test/unit/coffee/ChannelManagerTests.coffee
@@ -12,6 +12,7 @@ describe 'ChannelManager', ->
 		@ChannelManager = SandboxedModule.require modulePath, requires:
 			"settings-sharelatex": @settings = {}
 			"metrics-sharelatex": @metrics = {inc: sinon.stub(), summary: sinon.stub()}
+			"logger-sharelatex": @logger = { log: sinon.stub(), warn: sinon.stub(), error: sinon.stub() }
 
 	describe "subscribe", ->
 


### PR DESCRIPTION
#### Description

The ChannelManagerTests are very verbose due to a missing logger stub -- lost in https://github.com/overleaf/real-time/pull/137

Acceptance tests: backport https://github.com/overleaf/real-time/pull/110

#### Related Issues / PRs

https://github.com/overleaf/real-time/pull/110

