### PR TITLE
[misc] add test cases for the validation of the callback argument

### DIFF
--- a/app/coffee/Router.coffee
+++ b/app/coffee/Router.coffee
@@ -26,6 +26,7 @@ module.exports = Router =
 				logger.warn attrs, error.message, code: error.code
 				return callback {message: error.message, code: error.code}
 			if error.message == 'unexpected arguments'
+				# the payload might be very large, put it on level info
 				logger.log attrs, 'unexpected arguments'
 				metrics.inc 'unexpected-arguments', 1, { status: method }
 				return callback { message: error.message }

--- a/test/acceptance/coffee/RouterTests.coffee
+++ b/test/acceptance/coffee/RouterTests.coffee
@@ -1,0 +1,76 @@
+async = require "async"
+{expect} = require("chai")
+
+RealTimeClient = require "./helpers/RealTimeClient"
+FixturesManager = require "./helpers/FixturesManager"
+
+
+describe "Router", ->
+	describe "joinProject", ->
+		describe "when there is no callback provided", ->
+			after () ->
+				process.removeListener('unhandledRejection', @onUnhandled)
+
+			before (done) ->
+				@onUnhandled = (error) ->
+					done(error)
+				process.on('unhandledRejection', @onUnhandled)
+				async.series [
+					(cb) =>
+						FixturesManager.setUpProject {
+							privilegeLevel: "owner"
+							project: {
+								name: "Test Project"
+							}
+						}, (e, {@project_id, @user_id}) =>
+							cb(e)
+
+					(cb) =>
+						@client = RealTimeClient.connect()
+						@client.on "connectionAccepted", cb
+
+					(cb) =>
+						@client = RealTimeClient.connect()
+						@client.on "connectionAccepted", cb
+
+					(cb) =>
+						@client.emit "joinProject", project_id: @project_id
+						setTimeout(cb, 100)
+				], done
+
+			it "should keep on going", ->
+				expect('still running').to.exist
+
+		describe "when there are too many arguments", ->
+			after () ->
+				process.removeListener('unhandledRejection', @onUnhandled)
+
+			before (done) ->
+				@onUnhandled = (error) ->
+					done(error)
+				process.on('unhandledRejection', @onUnhandled)
+				async.series [
+					(cb) =>
+						FixturesManager.setUpProject {
+							privilegeLevel: "owner"
+							project: {
+								name: "Test Project"
+							}
+						}, (e, {@project_id, @user_id}) =>
+							cb(e)
+
+					(cb) =>
+						@client = RealTimeClient.connect()
+						@client.on "connectionAccepted", cb
+
+					(cb) =>
+						@client = RealTimeClient.connect()
+						@client.on "connectionAccepted", cb
+
+					(cb) =>
+						@client.emit "joinProject", 1, 2, 3, 4, 5, (@error) =>
+							cb()
+				], done
+
+			it "should return an error message", ->
+				expect(@error.message).to.equal('unexpected arguments')


### PR DESCRIPTION
#### Description

Add acceptance tests for #141 (v2) and #147 (backport).

#### Related Issues / PRs

#141 and #147 (backport)
https://github.com/overleaf/issues/issues/3067

### Review

_Also add a note on the low log level of the `attrs` for `'unexpected arguments'`._


#### Potential Impact

Low, adds tests.