### PR TITLE
[backport] 111 HttpController: 404 for missing clients and add tests

### DIFF
--- a/app/coffee/HttpController.coffee
+++ b/app/coffee/HttpController.coffee
@@ -30,8 +30,10 @@ module.exports = HttpController =
 	getConnectedClient: (req, res, next) ->
 		{client_id} = req.params
 		io = req.app.get("io")
-		ioClient = io.sockets.socket(client_id)
+		ioClient = io.sockets.sockets[client_id]
+		if !ioClient
+			res.sendStatus(404)
+			return
 		HttpController._getConnectedClientView ioClient, (error, client) ->
 			return next(error) if error?
 			res.json client
-		

--- a/test/acceptance/coffee/HttpControllerTests.coffee
+++ b/test/acceptance/coffee/HttpControllerTests.coffee
@@ -1,0 +1,68 @@
+async = require('async')
+expect = require('chai').expect
+request = require('request').defaults({
+	baseUrl: 'http://localhost:3026'
+})
+
+RealTimeClient = require "./helpers/RealTimeClient"
+FixturesManager = require "./helpers/FixturesManager"
+
+describe 'HttpControllerTests', ->
+	describe 'without a user', ->
+		it 'should return 404 for the client view', (done) ->
+			client_id = 'not-existing'
+			request.get {
+				url: "/clients/#{client_id}"
+				json: true
+			}, (error, response, data) ->
+				return done(error) if error
+				expect(response.statusCode).to.equal(404)
+				done()
+
+	describe 'with a user and after joining a project', ->
+		before (done) ->
+			async.series [
+				(cb) =>
+					FixturesManager.setUpProject {
+						privilegeLevel: "owner"
+					}, (error, {@project_id, @user_id}) =>
+						cb(error)
+
+				(cb) =>
+					FixturesManager.setUpDoc @project_id, {}, (error, {@doc_id}) =>
+						cb(error)
+
+				(cb) =>
+					@client = RealTimeClient.connect()
+					@client.on "connectionAccepted", cb
+
+				(cb) =>
+					@client.emit "joinProject", {@project_id}, cb
+
+				(cb) =>
+					@client.emit "joinDoc", @doc_id, cb
+			], done
+
+		it 'should send a client view', (done) ->
+			request.get {
+				url: "/clients/#{@client.socket.sessionid}"
+				json: true
+			}, (error, response, data) =>
+				return done(error) if error
+				expect(response.statusCode).to.equal(200)
+				expect(data.connected_time).to.exist
+				delete data.connected_time
+				# .email is not set in the session
+				delete data.email
+				expect(data).to.deep.equal({
+					client_id: @client.socket.sessionid,
+					first_name: 'Joe',
+					last_name: 'Bloggs',
+					project_id: @project_id,
+					user_id: @user_id,
+					rooms: [
+						@project_id,
+						@doc_id,
+					]
+				})
+				done()


### PR DESCRIPTION
#### Description

Backport #111 which adds acceptance tests for the HttpController (and changes the behavior for missing clients to not create a new client, but return a 404)

#### Related Issues / PRs

#111

