### PR TITLE
[misc] RoomManager: emitOnCompletion: properly handle Promise rejections

### DIFF
--- a/app/coffee/RoomManager.coffee
+++ b/app/coffee/RoomManager.coffee
@@ -39,9 +39,9 @@ module.exports = RoomManager =
             @leaveEntity client, entity, id
 
     emitOnCompletion: (promiseList, eventName) ->
-        result = Promise.all(promiseList)
-        result.then () -> RoomEvents.emit(eventName)
-        result.catch (err) -> RoomEvents.emit(eventName, err)
+        Promise.all(promiseList)
+          .then(() -> RoomEvents.emit(eventName))
+          .catch((err) -> RoomEvents.emit(eventName, err))
 
     eventSource: () ->
         return RoomEvents


### PR DESCRIPTION
#### Description

I stumbled across this unhandled rejection during a rework of the RoomManager
 in my fork. I am really unsure how we missed it previously.

```
result = Promise.all([<Promise that rejects eventually>]) # rejection 1
result.then () -> RoomEvents.emit(eventName)              # rejection 2
result.catch (err) -> RoomEvents.emit(eventName, err)     # handle r1
```
As shown above, the second rejection remains unhandled. The fix is to
 chain the `.catch()` onto the `.then()` Promise.

#### Potential Impact

Low.

#### Manual Testing Performed

- added unit test
