### PR TITLE
[misc] optionally expose the hostname in the 'debug.getHostname' rpc

### DIFF
--- a/app/js/Router.js
+++ b/app/js/Router.js
@@ -21,6 +21,8 @@ const httpAuth = basicAuth(function (user, pass) {
   return isValid
 })
 
+const HOSTNAME = require('os').hostname()
+
 let Router
 module.exports = Router = {
   _handleError(callback, error, client, method, attrs) {
@@ -155,6 +157,19 @@ module.exports = Router = {
         ;({ user } = session)
       } else {
         user = { _id: 'anonymous-user' }
+      }
+
+      if (settings.exposeHostname) {
+        client.on('debug.getHostname', function (callback) {
+          if (typeof callback !== 'function') {
+            return Router._handleInvalidArguments(
+              client,
+              'debug.getHostname',
+              arguments
+            )
+          }
+          callback(HOSTNAME)
+        })
       }
 
       client.on('joinProject', function (data, callback) {

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -109,6 +109,9 @@ const settings = {
 
   cookieName: process.env.COOKIE_NAME || 'sharelatex.sid',
 
+  // Expose the hostname in the `debug.getHostname` rpc
+  exposeHostname: process.env.EXPOSE_HOSTNAME === 'true',
+
   max_doc_length: 2 * 1024 * 1024, // 2mb
 
   // combine


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3263

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3263

#### Potential Impact

Low. Only adds new rpc endpoint.

#### Manual Testing Performed

- checkout `jpa-expose-hostname` in the dev-env
- open the editor
- `_ide.socket.emit('debug.getHostname', console.log)`

#### Deployment Checklist

- [ ] https://github.com/overleaf/google-ops/pull/1130

