### PR TITLE
[misc] fix express deprecations

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,7 +68,7 @@ app.get('/', (req, res) => res.send('real-time-sharelatex is alive'))
 
 app.get('/status', function (req, res) {
   if (Settings.shutDownInProgress) {
-    res.send(503) // Service unavailable
+    res.sendStatus(503) // Service unavailable
   } else {
     res.send('real-time-sharelatex is alive')
   }

--- a/app/js/HttpApiController.js
+++ b/app/js/HttpApiController.js
@@ -23,7 +23,7 @@ module.exports = {
         req.body
       )
     }
-    res.send(204)
+    res.sendStatus(204)
   },
 
   startDrain(req, res) {
@@ -32,7 +32,7 @@ module.exports = {
     rate = parseFloat(rate) || 0
     logger.log({ rate }, 'setting client drain rate')
     DrainManager.startDrain(io, rate)
-    res.send(204)
+    res.sendStatus(204)
   },
 
   disconnectClient(req, res, next) {


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/2965

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/2965

#### Potential Impact

High, but `app/js/HttpApiController.js` is covered by acceptance tests.

Running the acceptance tests locally showed the deprecation warning -- in CI they are not logged for some reason :shrug: .

<details>

<pre>
real-time$ make test_acceptance
...

  DrainManagerTests
    ✓ should have disconnected all previous clients
    with two clients in the project
      starting to drain
express deprecated res.send(status): Use res.sendStatus(status) instead app/js/HttpApiController.js:35:9
</pre>
</details>


#### Manual testing performed

- start dev-env
- edit project