### PR TITLE
[misc] bump socket.io and socket.io-client: harden cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -449,7 +449,7 @@
     "active-x-obfuscator": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/active-x-obfuscator/-/active-x-obfuscator-0.0.1.tgz",
-      "integrity": "sha512-8gdEZinfLSCfAUulETDth4ZSIDPSchiPgm5PLrXQC6BANf1YFEDrPPM2MdK2zcekMROwtM667QFuYw/H6ZV06Q==",
+      "integrity": "sha1-CJuJs3FF/x2ex0r2UwvlUmyuHxo=",
       "requires": {
         "zeparser": "0.0.5"
       }
@@ -862,6 +862,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+      "integrity": "sha1-0SG7roYNmZKj1Re6lvVliOR8Z4E="
     },
     "common-tags": {
       "version": "1.8.0",
@@ -3128,7 +3133,7 @@
     "options": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-      "integrity": "sha512-bOj3L1ypm++N+n7CEbbe473A414AB7z+amKYshRb//iuL3MpdDCLhPnw6aVTdKB9g5ZRVHIEp8eUln6L2NUStg=="
+      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -3280,7 +3285,7 @@
     "policyfile": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/policyfile/-/policyfile-0.0.4.tgz",
-      "integrity": "sha512-UfDtlscNialXfmVEwEPm0t/5qtM0xPK025eYWd/ilv89hxLIhVQmt3QIzMHincLO2MBtZyww0386pt13J4aIhQ=="
+      "integrity": "sha1-1rgurZiueeviKOLa9ZAzEeyYLk0="
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -4532,26 +4537,26 @@
       }
     },
     "socket.io": {
-      "version": "https://github.com/overleaf/socket.io/archive/0.9.19-overleaf-2.tar.gz",
-      "integrity": "sha512-BVxF8Wz4FTj2hxiBtujKQUAihdVzxjSaJ++k/wr7pJfAt30kmyOXLkfyvFDzZISQ9SyDa2B4nBYJP3+MKBpaAg==",
+      "version": "https://github.com/overleaf/socket.io/archive/0.9.19-overleaf-3.tar.gz",
+      "integrity": "sha512-x07f3i4f3/CXaTBpUT/mH4JtYf3xjZWO0tvIB43Nn8OnzeRhMaKxhMZWcLQxfPdcaAyvafwLeM06fiDpHCaIYw==",
       "requires": {
         "base64id": "0.1.0",
         "policyfile": "0.0.4",
         "redis": "0.7.3",
-        "socket.io-client": "https://github.com/overleaf/socket.io-client/archive/0.9.17-overleaf-1.tar.gz"
+        "socket.io-client": "https://github.com/overleaf/socket.io-client/archive/0.9.17-overleaf-2.tar.gz"
       },
       "dependencies": {
         "redis": {
           "version": "0.7.3",
           "resolved": "https://registry.npmjs.org/redis/-/redis-0.7.3.tgz",
-          "integrity": "sha512-0Pgb0jOLfn6eREtEIRn/ifyZJjl2H+wUY4F/Pe7T4UhmoSrZ/1HU5ZqiBpDk8I8Wbyv2N5DpXKzbEtMj3drprg==",
+          "integrity": "sha1-7le3pE0l7BWU5ENl2BZfp9HUgRo=",
           "optional": true
         }
       }
     },
     "socket.io-client": {
-      "version": "https://github.com/overleaf/socket.io-client/archive/0.9.17-overleaf-1.tar.gz",
-      "integrity": "sha512-MchfS0GCu0BVbJXRk+HfHme5jHPWMDrNifbOhXZHJBtF03dLfCJcMPLYMQBtBGWQrrZsqXI0O9P3BO3hu0cPLA==",
+      "version": "https://github.com/overleaf/socket.io-client/archive/0.9.17-overleaf-2.tar.gz",
+      "integrity": "sha512-u8jEVctc4nFrN1JfjLeFjSSxXxGYo6hHxYW4rhv6aeoiaWkTmdaUzaG1YkDfSwBG/TXmdHx32UJB4fClmz8IEg==",
       "requires": {
         "active-x-obfuscator": "0.0.1",
         "uglify-js": "1.2.5",
@@ -4835,7 +4840,7 @@
     "tinycolor": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
-      "integrity": "sha512-+CorETse1kl98xg0WAzii8DTT4ABF4R3nquhrkIbVGcw1T8JYs5Gfx9xEfGINPUZGDj9C4BmOtuKeaTtuuRolg=="
+      "integrity": "sha1-MgtaUtg6u1l42Bo+iH1K77FaYWQ="
     },
     "tmp": {
       "version": "0.0.33",
@@ -4960,7 +4965,7 @@
     "uglify-js": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.2.5.tgz",
-      "integrity": "sha512-Ps1oQryKOcRDYuAN1tGpPWd/DIRMcdLz4p7JMxLjJiFvp+aaG01IEu0ZSoVvYUSxIkvW7k2X50BCW2InguEGlg=="
+      "integrity": "sha1-tULCx29477NLIAsgF3Y0Mw/3ArY="
     },
     "uid-safe": {
       "version": "2.1.5",
@@ -5182,7 +5187,7 @@
     "ws": {
       "version": "0.4.32",
       "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.32.tgz",
-      "integrity": "sha512-htqsS0U9Z9lb3ITjidQkRvkLdVhQePrMeu475yEfOWkAYvJ6dSjQp1tOH6ugaddzX5b7sQjMPNtY71eTzrV/kA==",
+      "integrity": "sha1-eHphVEFPPJntg8V3IVOyD+sM7DI=",
       "requires": {
         "commander": "~2.1.0",
         "nan": "~1.0.0",
@@ -5190,22 +5195,17 @@
         "tinycolor": "0.x"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
-          "integrity": "sha512-J2wnb6TKniXNOtoHS8TSrG9IOQluPrsmyAJ8oCUJOBmv+uLBCyPYAZkD2jFvw2DCzIXNnISIM01NIvr35TkBMQ=="
-        },
         "nan": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/nan/-/nan-1.0.0.tgz",
-          "integrity": "sha512-Wm2/nFOm2y9HtJfgOLnctGbfvF23FcQZeyUZqDD8JQG3zO5kXh3MkQKiUaA68mJiVWrOzLFkAV1u6bC8P52DJA=="
+          "integrity": "sha1-riT4hQgY1mL8q1rPfzuVv6oszzg="
         }
       }
     },
     "xmlhttprequest": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.4.2.tgz",
-      "integrity": "sha512-WTsthd44hTdCRrHkdtTgbgTKIJyNDV+xiShdooFZBUstY7xk+EXMx/u5gjuUXaCiCWvtBVCHwauzml2joevB4w=="
+      "integrity": "sha1-AUU6HZvtHo8XL2SVu/TIxCYyFQA="
     },
     "y18n": {
       "version": "4.0.0",
@@ -5307,7 +5307,7 @@
     "zeparser": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/zeparser/-/zeparser-0.0.5.tgz",
-      "integrity": "sha512-Qj4lJIRPy7hIW1zCBqwA3AW8F9uHswVoXPnotuY6uyNgbg5qGb6SJfWZi+YzD3DktbUnUoGiGZFhopbn9l1GYw=="
+      "integrity": "sha1-A3JlYbwmjy5URPVMZlt/1KjAKeI="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "redis-sharelatex": "^1.0.13",
     "request": "^2.88.2",
     "settings-sharelatex": "^1.1.0",
-    "socket.io": "https://github.com/overleaf/socket.io/archive/0.9.19-overleaf-2.tar.gz",
-    "socket.io-client": "https://github.com/overleaf/socket.io-client/archive/0.9.17-overleaf-1.tar.gz"
+    "socket.io": "https://github.com/overleaf/socket.io/archive/0.9.19-overleaf-3.tar.gz",
+    "socket.io-client": "https://github.com/overleaf/socket.io-client/archive/0.9.17-overleaf-2.tar.gz"
   },
   "devDependencies": {
     "bunyan": "~0.22.3",


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3371
Pull in https://github.com/overleaf/socket.io/pull/4 and https://github.com/overleaf/socket.io-client/pull/2

> Gracefully access transport methods, when the transport/WebSocket may not exist yet/anymore.

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3371
https://github.com/overleaf/socket.io/pull/4
https://github.com/overleaf/socket.io-client/pull/2

### Review

The socket.io packages are not tagged yet, I am using branches for testing in real-time first.
Before merging I will remove the `jpa-test-release-` prefix.

The integrity hash downgrades are expected, see https://github.com/overleaf/issues/issues/3252#issuecomment-665096798

#### Potential Impact

High, this is changing the connect code path -- I verified that the editor load, aka has a working connection.

#### Manual Testing Performed

See https://github.com/overleaf/socket.io-client/pull/2

> Testing this is tricky. The most reliable method so far has been disabling the websocket transport and toggling between offline-mode and slow 3G network connectivity. Specifically using slow 3G for the handshake and disconnecting after receiving the response. The transport request will then error out and the heartbeat timeout will attempt to close the transport -- which has not been setup yet. Calling `_ide.socket.socket.disconnect()` when the editor has no working connection may trigger the exception as well -- we call it from the reconnect logic in web here: https://github.com/overleaf/web-internal/blob/9ebea48f333cc3dcff2b4caae54894f5f1151618/frontend/js/ide/connection/ConnectionManager.js#L478-L481 or from the editor logic when the user kept editing and got into an out-of-sync state: https://github.com/overleaf/web-internal/blob/1069f9301fb74680dbe23a71b634ec6d4e1278c8/frontend/js/ide/editor/EditorManager.js#L249

#### Deployment Checklist

- remove `jpa-test-release-` prefixes and run `bin/run real-time npm i`
