### PR TITLE
[misc] bump the dev-env to 3.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 forever
+
+# managed by dev-environment$ bin/update_build_scripts
+.npmrc

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-# block local, outside docker invocations of $ npm install
-dry-run=true

--- a/buildscript.txt
+++ b/buildscript.txt
@@ -5,4 +5,4 @@ real-time
 --env-pass-through=
 --node-version=10.21.0
 --public-repo=True
---script-version=3.3.0
+--script-version=3.3.1


### PR DESCRIPTION
### Description

For https://github.com/overleaf/dev-environment/pull/380

Blocking local npm-install broke the Server CE/Pro build.

The npmrc will now live in a git-ignored file, generated by the Makefile of the dev-env.

#### Related Issues / PRs

https://github.com/overleaf/dev-environment/pull/380
Closes https://github.com/overleaf/overleaf/issues/764

#### Potential Impact

None for production.
