### PR TITLE
[app] ignore errors from accessing disconnected client sockets

### DIFF
--- a/app.js
+++ b/app.js
@@ -181,7 +181,11 @@ if (Settings.shutdownDrainTimeWindow) {
   if (Settings.errors && Settings.errors.catchUncaughtErrors) {
     process.removeAllListeners('uncaughtException')
     process.on('uncaughtException', function (error) {
-      if (['EPIPE', 'ECONNRESET'].includes(error.code)) {
+      if (
+        ['ETIMEDOUT', 'EHOSTUNREACH', 'EPIPE', 'ECONNRESET'].includes(
+          error.code
+        )
+      ) {
         Metrics.inc('disconnected_write', 1, { status: error.code })
         return logger.warn(
           { err: error },


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3419

We were seeing invalid socket access on potentially gone client socket. This lead to a shutdown of all real-time nodes.

As an intermediate fix we are going to swallow the seen error codes, that are specifically tied to invalid socket access.
The continuous pub-sub traffic/health-check ensures that we notice errors from out-going redis traffic that ends up with the same error code.

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3419

### Review

Technically `EHOSTUNREACH` and `ETIMEDOUT` should go into a
 'disconnected_read' metric. But this would require changes to
 dashboards and a larger diff.

#### Potential Impact

High. Breaking the signal listener could crash real-time too frequently. I am adding entries into the check list only.

#### Manual Testing Performed

We do not have a reproducer yet.

#### Metrics and Monitoring

The codes `EHOSTUNREACH` and `ETIMEDOUT` may appear in the  `disconnected_write` metric some day.
