### PR TITLE
[misc] bump socket.io and socket.io-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4537,13 +4537,13 @@
       }
     },
     "socket.io": {
-      "version": "https://github.com/overleaf/socket.io/archive/0.9.19-overleaf-3.tar.gz",
-      "integrity": "sha512-x07f3i4f3/CXaTBpUT/mH4JtYf3xjZWO0tvIB43Nn8OnzeRhMaKxhMZWcLQxfPdcaAyvafwLeM06fiDpHCaIYw==",
+      "version": "https://github.com/overleaf/socket.io/archive/0.9.19-overleaf-4.tar.gz",
+      "integrity": "sha512-jWgdvVEbPioarWhfKvmtFf9miv/TYMePwrWO+r3WlVF+07nPkWY+OK0y0Lob5shC/dTLqwyG9ajw49+ObC8s/A==",
       "requires": {
         "base64id": "0.1.0",
         "policyfile": "0.0.4",
         "redis": "0.7.3",
-        "socket.io-client": "https://github.com/overleaf/socket.io-client/archive/0.9.17-overleaf-2.tar.gz"
+        "socket.io-client": "https://github.com/overleaf/socket.io-client/archive/0.9.17-overleaf-3.tar.gz"
       },
       "dependencies": {
         "redis": {
@@ -4555,8 +4555,8 @@
       }
     },
     "socket.io-client": {
-      "version": "https://github.com/overleaf/socket.io-client/archive/0.9.17-overleaf-2.tar.gz",
-      "integrity": "sha512-u8jEVctc4nFrN1JfjLeFjSSxXxGYo6hHxYW4rhv6aeoiaWkTmdaUzaG1YkDfSwBG/TXmdHx32UJB4fClmz8IEg==",
+      "version": "https://github.com/overleaf/socket.io-client/archive/0.9.17-overleaf-3.tar.gz",
+      "integrity": "sha512-EtKV6qGQjG/DwMXfLAiS559f07xjPVavYZ+amYwiEZ0FUHdLObuGH3zvoxghjbI6l8gFTflQhGt1foiHIGnDKg==",
       "requires": {
         "active-x-obfuscator": "0.0.1",
         "uglify-js": "1.2.5",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "redis-sharelatex": "^1.0.13",
     "request": "^2.88.2",
     "settings-sharelatex": "^1.1.0",
-    "socket.io": "https://github.com/overleaf/socket.io/archive/0.9.19-overleaf-3.tar.gz",
-    "socket.io-client": "https://github.com/overleaf/socket.io-client/archive/0.9.17-overleaf-2.tar.gz"
+    "socket.io": "https://github.com/overleaf/socket.io/archive/0.9.19-overleaf-4.tar.gz",
+    "socket.io-client": "https://github.com/overleaf/socket.io-client/archive/0.9.17-overleaf-3.tar.gz"
   },
   "devDependencies": {
     "bunyan": "~0.22.3",


### PR DESCRIPTION
### Description

Followup for #173 
For https://github.com/overleaf/issues/issues/3371
Pull in https://github.com/overleaf/socket.io/pull/5 and https://github.com/overleaf/socket.io-client/pull/3

> - harden the cleanup of sockets/transports
>    Delayed inflight of packages may trigger a heartbeat after closing the transport.

#### Related Issues / PRs

#173 
https://github.com/overleaf/issues/issues/3371
https://github.com/overleaf/socket.io/pull/5
https://github.com/overleaf/socket.io-client/pull/3

### Review

The socket.io packages are not tagged yet, I am using branches for testing in real-time first.
Before merging I will remove the `jpa-test-release-` prefix.

#### Potential Impact

High, this is changing the health-check code path. It is non trivial to get into the in https://github.com/overleaf/socket.io-client/pull/3 described race condition tho.

#### Manual Testing Performed

See https://github.com/overleaf/socket.io-client/pull/3

Testing this is even trickier than #173. The race condition  https://github.com/overleaf/socket.io-client/pull/3 is fixing is working like this:

- connection setup for ws fails, eventually downgrade to long-polling
- working connection receives traffic
- client closes the connection
- no more transport to try `socket.transport=null`
- packet arrives after the transport was closed and triggers hearthbeat
- heartbeat may access `socket.transport`

#### Deployment Checklist

- remove `jpa-test-release-` prefixes and run `bin/run real-time npm i`
