### PR TITLE
[misc] forcefully disconnect from shutdown process

### DIFF
--- a/app.js
+++ b/app.js
@@ -98,7 +98,16 @@ function healthCheck(req, res) {
     }
   })
 }
-app.get('/health_check', healthCheck)
+app.get(
+  '/health_check',
+  (req, res, next) => {
+    if (Settings.shutDownComplete) {
+      return res.sendStatus(503)
+    }
+    next()
+  },
+  healthCheck
+)
 
 app.get('/health_check/redis', healthCheck)
 
@@ -167,6 +176,8 @@ function drainAndShutdown(signal) {
               client.disconnect()
             })
           }
+          // Mark the node as unhealthy.
+          Settings.shutDownComplete = true
         }, Settings.gracefulReconnectTimeoutMs)
       })
       shutdownCleanly(signal)

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -123,6 +123,16 @@ const settings = {
 
   shutdownDrainTimeWindow: process.env.SHUTDOWN_DRAIN_TIME_WINDOW || 9,
 
+  // The shutdown procedure asks clients to reconnect gracefully.
+  // 3rd-party/buggy clients may not act upon receiving the message and keep
+  //  stale connections alive. We forcefully disconnect them after X ms:
+  gracefulReconnectTimeoutMs:
+    parseInt(process.env.GRACEFUL_RECONNECT_TIMEOUT_MS, 10) ||
+    // The frontend allows actively editing users to keep the connection open
+    //  for up-to ConnectionManager.MAX_RECONNECT_GRACEFULLY_INTERVAL=45s
+    // Permit an extra delay to account for slow/flaky connections.
+    (45 + 30) * 1000,
+
   continualPubsubTraffic: process.env.CONTINUAL_PUBSUB_TRAFFIC || false,
 
   checkEventOrder: process.env.CHECK_EVENT_ORDER || false,


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3419

The shutdown process asks clients to reconnect, but some clients may be broken/ignore the message.
This leaves the real-time processes in an unhealthy state indefinitely.

This PR waits for all clients to get asked for a reconnect and after a configurable delay `GRACEFUL_RECONNECT_TIMEOUT_MS` it disconnects them forcefully.

The default delay is 45s + 30s. The 45s are [coming from the frontend](https://github.com/overleaf/web/blob/eb84e0d4eb2ea83e9f31753b10297e71ae3d02c2/frontend/js/ide/connection/ConnectionManager.js#L32) -- it permits users to keep editing. I added 30s to allow users with a bad internet connectivity to receive the graceful reconnect message and flush their send queue.

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3419

#### Potential Impact

Low. Affects the shutdown process only.

#### Manual Testing Performed

- add signal forwarding to the node-process, skip nodemon for real-time:

<details>

```diff
diff --git a/docker-compose.yml b/docker-compose.yml
index f12e4fe91..f6dc76611 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,6 +123,7 @@ services:
     extends:
       file: common.yml
       service: common
+    command: node --expose-gc app.js
     volumes:
       - ./real-time:/app:cached
     ports:
```
</details>

- `dev-env$ bin/up core`
- open a project in the editor
- in the browser console, create a few new headless clients `io.connect(null, {'force new connection': 1})`
- tail logs `dev-env$ docker-compose logs --tail=10 -f real-time`
- curl the app health check: `$ curl 127.0.0.1:3026/health_check` -> `OK`
- shutdown real-time with a long timeout `dev-env$ docker-compose stop -t900 real-time`
- see the reconnectGracefully requests in the log
- see the number of headless clients in the log message of periodic shutdownCleanly polling

   > `"connectedClients":30,"msg":"clients still connected, not shutting down yet"`
- eventually (after about 45s+30s) see `forcefully disconnecting stale clients` with the client ids of the headless clients

  > `"staleClients":["stlPGKhEqVYBDGMouRnE", ... ,"Xgb5CrjJxMJgB9N_uRnh"],"msg":"forcefully disconnecting stale clients"`
- curl the app health check: `$ curl 127.0.0.1:3026/health_check` -> `Service Unavailable`
- curl the redis health check: `$ curl 127.0.0.1:3026/health_check/redis` -> `OK`
- eventually (<30s) `shutdownCleanly` emits `no clients connected, exiting` and the process exits

