### PR TITLE
[misc] increase the timeout for unit tests -- CI boxes are too slow

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "node $NODE_APP_OPTIONS app.js",
     "test:acceptance:_run": "mocha --recursive --reporter spec --timeout 15000 --exit $@ test/acceptance/js",
     "test:acceptance": "npm run test:acceptance:_run -- --grep=$MOCHA_GREP",
-    "test:unit:_run": "mocha --recursive --reporter spec $@ test/unit/js",
+    "test:unit:_run": "mocha --recursive --reporter spec --timeout 5000 $@ test/unit/js",
     "test:unit": "npm run test:unit:_run -- --grep=$MOCHA_GREP",
     "nodemon": "nodemon --config nodemon.json",
     "lint": "node_modules/.bin/eslint --max-warnings 0 .",


### PR DESCRIPTION
### Description

As per the title. All my cloud builds for the reworked logging were failing due to timeouts. The tests are completing just fine locally.

https://digital-science.slack.com/archives/C20TZCMMF/p1598009512014800

#### Potential Impact

None for production.
