### PR TITLE
[misc] add/bring back doc_id in error context

### DIFF
--- a/app/js/Router.js
+++ b/app/js/Router.js
@@ -27,7 +27,7 @@ let Router
 module.exports = Router = {
   _handleError(callback, error, client, method, attrs) {
     attrs = attrs || {}
-    for (const key of ['project_id', 'doc_id', 'user_id']) {
+    for (const key of ['project_id', 'user_id']) {
       attrs[key] = client.ol_context[key]
     }
     attrs.client_id = client.id

--- a/app/js/Router.js
+++ b/app/js/Router.js
@@ -274,7 +274,9 @@ module.exports = Router = {
 
         WebsocketController.leaveDoc(client, doc_id, function (err, ...args) {
           if (err) {
-            Router._handleError(callback, err, client, 'leaveDoc')
+            Router._handleError(callback, err, client, 'leaveDoc', {
+              doc_id
+            })
           } else {
             callback(null, ...args)
           }


### PR DESCRIPTION
### Description

Part of https://github.com/overleaf/issues/issues/3265

The `doc_id` is not part of the `ol_context` (and was not part of the socket.io context before that). It may come from the caller context instead. Additionally add the `doc_id` from the `leaveDoc` rpc.

Chained onto #183 to make the unit tests pass in CI -- they pass locally without #183 .

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3265

#### Potential Impact

Low. May help in debugging failing joinDoc/leaveDoc rpcs.

#### Manual Testing Performed

- run unit/acceptance tests
- editor works
- join not existing doc via the browser console -- e.g. `_ide.socket.emit('joinDoc, '5f0a31aa0e69950001550000', console.log)` and see `doc_id` in the logs.
