### PR TITLE
[misc] fix join project error context

### DIFF
--- a/app/js/Router.js
+++ b/app/js/Router.js
@@ -28,7 +28,7 @@ module.exports = Router = {
   _handleError(callback, error, client, method, attrs) {
     attrs = attrs || {}
     for (const key of ['project_id', 'user_id']) {
-      attrs[key] = client.ol_context[key]
+      attrs[key] = attrs[key] || client.ol_context[key]
     }
     attrs.client_id = client.id
     attrs.err = error


### PR DESCRIPTION
### Description

Part of https://github.com/overleaf/issues/issues/3265

The ol_context patch changed the priority of client context and rpc
context.
This lead to the (possibly missing) project_id of the client context
overwriting the project_id of the rpc context.
REF: f1d55c0a5437a518e9f4617473caed9ba928e648

Chained onto #185 as these two would create a merge-conflict otherwise.

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3265

#### Potential Impact

Low. Affects debugging of failing joinProject rpcs on already joined connections (not actually supported). 

#### Manual Testing Performed

- run unit/acceptance tests
- editor works
- join not existing doc/project via the browser console -- e.g. `_ide.socket.emit('joinProject', {project_id: '5f0a31aa0e69950001550000'}, console.log)` and see the rpc project_id in the logs.
