### PR TITLE
[misc] migrate to OError tagging/wrapping

### DIFF
--- a/app/js/ChannelManager.js
+++ b/app/js/ChannelManager.js
@@ -1,6 +1,7 @@
 const logger = require('logger-sharelatex')
 const metrics = require('metrics-sharelatex')
 const settings = require('settings-sharelatex')
+const OError = require('@overleaf/o-error')
 
 const ClientMap = new Map() // for each redis client, store a Map of subscribed channels (channelname -> subscribe promise)
 
@@ -35,6 +36,8 @@ module.exports = {
         .catch(function (err) {
           logger.error({ channel, err }, 'failed to subscribe to channel')
           metrics.inc(`subscribe.failed.${baseChannel}`)
+          // add context for the stack-trace at the call-site
+          OError.tag(err, 'failed to subscribe to channel', { channel })
         })
       return p
     }

--- a/app/js/ConnectedUsersManager.js
+++ b/app/js/ConnectedUsersManager.js
@@ -5,6 +5,7 @@ const async = require('async')
 const Settings = require('settings-sharelatex')
 const logger = require('logger-sharelatex')
 const redis = require('redis-sharelatex')
+const OError = require('@overleaf/o-error')
 const rclient = redis.createClient(Settings.redis.realtime)
 const Keys = Settings.redis.realtime.key_schema
 
@@ -67,10 +68,7 @@ module.exports = {
 
     multi.exec(function (err) {
       if (err) {
-        logger.err(
-          { err, project_id, client_id },
-          'problem marking user as connected'
-        )
+        OError.tag(err, 'problem marking user as connected')
       }
       callback(err)
     })
@@ -104,7 +102,12 @@ module.exports = {
     multi.srem(Keys.clientsInProject({ project_id }), client_id)
     multi.expire(Keys.clientsInProject({ project_id }), FOUR_DAYS_IN_S)
     multi.del(Keys.connectedUser({ project_id, client_id }))
-    multi.exec(callback)
+    multi.exec(function (err) {
+      if (err) {
+        OError.tag(err, 'problem marking user as disconnected')
+      }
+      callback(err)
+    })
   },
 
   _getConnectedUser(project_id, client_id, callback) {
@@ -112,6 +115,12 @@ module.exports = {
       err,
       result
     ) {
+      if (err) {
+        OError.tag(err, 'problem fetching connected user details', {
+          other_client_id: client_id
+        })
+        return callback(err)
+      }
       if (!(result && result.user_id)) {
         result = {
           connected: false,
@@ -126,15 +135,10 @@ module.exports = {
           try {
             result.cursorData = JSON.parse(result.cursorData)
           } catch (e) {
-            logger.error(
-              {
-                err: e,
-                project_id,
-                client_id,
-                cursorData: result.cursorData
-              },
-              'error parsing cursorData JSON'
-            )
+            OError.tag(e, 'error parsing cursorData JSON', {
+              other_client_id: client_id,
+              cursorData: result.cursorData
+            })
             return callback(e)
           }
         }
@@ -150,6 +154,7 @@ module.exports = {
       results
     ) {
       if (err) {
+        OError.tag(err, 'problem getting clients in project')
         return callback(err)
       }
       const jobs = results.map((client_id) => (cb) =>
@@ -157,6 +162,7 @@ module.exports = {
       )
       async.series(jobs, function (err, users) {
         if (err) {
+          OError.tag(err, 'problem getting connected users')
           return callback(err)
         }
         users = users.filter(

--- a/app/js/ConnectedUsersManager.js
+++ b/app/js/ConnectedUsersManager.js
@@ -68,7 +68,7 @@ module.exports = {
 
     multi.exec(function (err) {
       if (err) {
-        OError.tag(err, 'problem marking user as connected')
+        err = new OError('problem marking user as connected').withCause(err)
       }
       callback(err)
     })
@@ -104,7 +104,7 @@ module.exports = {
     multi.del(Keys.connectedUser({ project_id, client_id }))
     multi.exec(function (err) {
       if (err) {
-        OError.tag(err, 'problem marking user as disconnected')
+        err = new OError('problem marking user as disconnected').withCause(err)
       }
       callback(err)
     })
@@ -116,9 +116,9 @@ module.exports = {
       result
     ) {
       if (err) {
-        OError.tag(err, 'problem fetching connected user details', {
+        err = new OError('problem fetching connected user details', {
           other_client_id: client_id
-        })
+        }).withCause(err)
         return callback(err)
       }
       if (!(result && result.user_id)) {
@@ -154,7 +154,7 @@ module.exports = {
       results
     ) {
       if (err) {
-        OError.tag(err, 'problem getting clients in project')
+        err = new OError('problem getting clients in project').withCause(err)
         return callback(err)
       }
       const jobs = results.map((client_id) => (cb) =>

--- a/app/js/DocumentUpdaterManager.js
+++ b/app/js/DocumentUpdaterManager.js
@@ -136,12 +136,12 @@ const DocumentUpdaterManager = {
       error
     ) {
       if (error) {
-        OError.tag(error, 'error pushing update into redis')
+        error = new OError('error pushing update into redis').withCause(error)
         return callback(error)
       }
       rclient.rpush('pending-updates-list', doc_key, function (error) {
         if (error) {
-          OError.tag(error, 'error pushing doc_id into redis')
+          error = new OError('error pushing doc_id into redis').withCause(error)
         }
         callback(error)
       })

--- a/app/js/DocumentUpdaterManager.js
+++ b/app/js/DocumentUpdaterManager.js
@@ -3,6 +3,7 @@
 */
 const request = require('request')
 const _ = require('underscore')
+const OError = require('@overleaf/o-error')
 const logger = require('logger-sharelatex')
 const settings = require('settings-sharelatex')
 const metrics = require('metrics-sharelatex')
@@ -23,10 +24,7 @@ const DocumentUpdaterManager = {
     request.get(url, function (err, res, body) {
       timer.done()
       if (err) {
-        logger.error(
-          { err, url, project_id, doc_id },
-          'error getting doc from doc updater'
-        )
+        OError.tag(err, 'error getting doc from doc updater')
         return callback(err)
       }
       if (res.statusCode >= 200 && res.statusCode < 300) {
@@ -37,6 +35,7 @@ const DocumentUpdaterManager = {
         try {
           body = JSON.parse(body)
         } catch (error) {
+          OError.tag(error, 'error parsing doc updater response')
           return callback(error)
         }
         body = body || {}
@@ -79,10 +78,7 @@ const DocumentUpdaterManager = {
     request.del(url, function (err, res) {
       timer.done()
       if (err) {
-        logger.error(
-          { err, project_id },
-          'error deleting project from document updater'
-        )
+        OError.tag(err, 'error deleting project from document updater')
         callback(err)
       } else if (res.statusCode >= 200 && res.statusCode < 300) {
         logger.log({ project_id }, 'deleted project from document updater')
@@ -140,9 +136,15 @@ const DocumentUpdaterManager = {
       error
     ) {
       if (error) {
+        OError.tag(error, 'error pushing update into redis')
         return callback(error)
       }
-      rclient.rpush('pending-updates-list', doc_key, callback)
+      rclient.rpush('pending-updates-list', doc_key, function (error) {
+        if (error) {
+          OError.tag(error, 'error pushing doc_id into redis')
+        }
+        callback(error)
+      })
     })
   }
 }

--- a/app/js/RoomManager.js
+++ b/app/js/RoomManager.js
@@ -4,6 +4,7 @@
 const logger = require('logger-sharelatex')
 const metrics = require('metrics-sharelatex')
 const { EventEmitter } = require('events')
+const OError = require('@overleaf/o-error')
 
 const IdMap = new Map() // keep track of whether ids are from projects or docs
 const RoomEvents = new EventEmitter() // emits {project,doc}-active and {project,doc}-empty events
@@ -65,6 +66,10 @@ module.exports = {
       logger.log({ entity, id }, 'room is now active')
       RoomEvents.once(`${entity}-subscribed-${id}`, function (err) {
         // only allow the client to join when all the relevant channels have subscribed
+        if (err) {
+          OError.tag(err, 'error joining', { entity, id })
+          return callback(err)
+        }
         logger.log(
           { client: client.id, entity, id, beforeCount },
           'client joined new room and subscribed to channel'

--- a/app/js/SessionSockets.js
+++ b/app/js/SessionSockets.js
@@ -1,3 +1,4 @@
+const OError = require('@overleaf/o-error')
 const { EventEmitter } = require('events')
 
 module.exports = function (io, sessionStore, cookieParser, cookieName) {
@@ -17,6 +18,9 @@ module.exports = function (io, sessionStore, cookieParser, cookieName) {
       }
       sessionStore.get(sessionId, function (error, session) {
         if (error) {
+          OError.tag(error, 'error getting session from sessionStore', {
+            sessionId
+          })
           return next(error, socket)
         }
         if (!session) {

--- a/app/js/WebApiManager.js
+++ b/app/js/WebApiManager.js
@@ -2,6 +2,7 @@
     camelcase,
 */
 const request = require('request')
+const OError = require('@overleaf/o-error')
 const settings = require('settings-sharelatex')
 const logger = require('logger-sharelatex')
 const { CodedError } = require('./Errors')
@@ -30,6 +31,7 @@ module.exports = {
       },
       function (error, response, data) {
         if (error) {
+          OError.tag(error, 'join project request failed')
           return callback(error)
         }
         let err

--- a/test/unit/js/ChannelManagerTests.js
+++ b/test/unit/js/ChannelManagerTests.js
@@ -91,7 +91,8 @@ describe('ChannelManager', function () {
         )
         p.then(() => done(new Error('should not subscribe but fail'))).catch(
           (err) => {
-            err.message.should.equal('some redis error')
+            err.message.should.equal('failed to subscribe to channel')
+            err.cause.message.should.equal('some redis error')
             this.ChannelManager.getClientMapEntry(this.rclient)
               .has('applied-ops:1234567890abcdef')
               .should.equal(false)

--- a/test/unit/js/WebsocketControllerTests.js
+++ b/test/unit/js/WebsocketControllerTests.js
@@ -1464,8 +1464,8 @@ describe('WebsocketController', function () {
         return this.client.disconnect.called.should.equal(true)
       })
 
-      it('should log an error', function () {
-        return this.logger.error.called.should.equal(true)
+      it('should not log an error', function () {
+        return this.logger.error.called.should.equal(false)
       })
 
       return it('should call the callback with the error', function () {


### PR DESCRIPTION
### Description

Part of https://github.com/overleaf/issues/issues/3265

This PR is split into two parts: the OError.tag migration and then a partial rollback as we noticed that ioredis reused error instances, which lead to attaching tags for unrelated contexts. E.g. `problem marking user as disconnected` and `problem getting clients in project` getting into the same tags array of an `MaxRetriesPerRequestError` instance.

See also this slack thread: https://digital-science.slack.com/archives/C20TZCMMF/p1598000301007200

---

See the docs of OError.tag:
https://github.com/overleaf/o-error#long-stack-traces-with-oerrortag
(currently at 221dd902e7bfa0ee92de1ea5a3cbf3152c3ceeb4)

I am tagging all errors at each async hop. Most of the controller code
 will only ever see already tagged errors -- or new errors created in
 our app code. They should have enough info that we do not need to tag
 them again.

---

ioredis may reuse the error instance for multiple callbacks. E.g. when
 the connection to redis fails, the queue is flushed with the same
 MaxRetriesPerRequestError instance.

---

Chained onto #183 to make the unit tests pass in CI -- they pass locally without #183 .

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3265

#### Review

What to look for: All callbacks from async contexts should have a `OError.tag` invocation before them. All redis callbacks should wrap the error using `new OError(message, [context]).withCause(originalRedisError)`. No intermediate logger invocations.

#### Potential Impact

Medium. Most of the error code paths.

#### Manual Testing Performed

- run unit/acceptance tests
- editor works
- join not existing doc/project via the browser console -- e.g. `_ide.socket.emit('joinDoc', '5f0a31aa0e69950001550000', console.log)` and see custom error names/tags
- break the redis config (e.g. remove the Settings details from the constructor) for a module and see eventually failing redis requests with the proper context.
