### PR TITLE
[misc] drop duplicate logs

### DIFF
--- a/app/js/WebApiManager.js
+++ b/app/js/WebApiManager.js
@@ -49,7 +49,6 @@ module.exports = {
             data.isRestrictedUser
           )
         } else if (response.statusCode === 429) {
-          logger.log(project_id, user_id, 'rate-limit hit when joining project')
           callback(
             new CodedError(
               'rate-limit hit when joining project',

--- a/app/js/WebsocketController.js
+++ b/app/js/WebsocketController.js
@@ -462,10 +462,6 @@ module.exports = WebsocketController = {
       update,
       function (error) {
         if (error) {
-          logger.warn(
-            { err: error, doc_id, client_id: client.id, version: update.v },
-            'client is not authorized to make update'
-          )
           setTimeout(
             () =>
               // Disconnect, but give the client the chance to receive the error

--- a/test/unit/js/WebsocketControllerTests.js
+++ b/test/unit/js/WebsocketControllerTests.js
@@ -1493,8 +1493,8 @@ describe('WebsocketController', function () {
       // it "should disconnect the client", ->
       // 	@client.disconnect.called.should.equal true
 
-      it('should log a warning', function () {
-        return this.logger.warn.called.should.equal(true)
+      it('should not log a warning', function () {
+        return this.logger.warn.called.should.equal(false)
       })
 
       return it('should call the callback with the error', function () {


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3265

The warn entry was missed in the tagging process as it's not directly above a callback.

#### Review

The errors are logged in `Router._handleError`.

#### Related Issues / PRs

#187 
https://github.com/overleaf/issues/issues/3265

#### Potential Impact

None. Deleted log lines.
