### PR TITLE
[misc] re-level expected error log messages

### DIFF
--- a/app/js/Router.js
+++ b/app/js/Router.js
@@ -33,6 +33,7 @@ module.exports = Router = {
     }
     attrs.client_id = client.id
     attrs.err = error
+    attrs.method = method
     if (error.name === 'CodedError') {
       logger.warn(attrs, error.message)
       const serializedError = { message: error.message, code: error.info.code }

--- a/app/js/WebApiManager.js
+++ b/app/js/WebApiManager.js
@@ -59,6 +59,8 @@ module.exports = {
           )
         } else if (response.statusCode === 403) {
           callback(new NotAuthorizedError())
+        } else if (response.statusCode === 404) {
+          callback(new CodedError('project not found', 'ProjectNotFound'))
         } else {
           callback(new WebApiRequestFailedError(response.statusCode))
         }

--- a/app/js/WebApiManager.js
+++ b/app/js/WebApiManager.js
@@ -8,6 +8,7 @@ const logger = require('logger-sharelatex')
 const {
   CodedError,
   CorruptedJoinProjectResponseError,
+  NotAuthorizedError,
   WebApiRequestFailedError
 } = require('./Errors')
 
@@ -56,6 +57,8 @@ module.exports = {
               'TooManyRequests'
             )
           )
+        } else if (response.statusCode === 403) {
+          callback(new NotAuthorizedError())
         } else {
           callback(new WebApiRequestFailedError(response.statusCode))
         }

--- a/app/js/WebsocketController.js
+++ b/app/js/WebsocketController.js
@@ -356,7 +356,7 @@ module.exports = WebsocketController = {
       cursorData.doc_id,
       function (error) {
         if (error) {
-          logger.warn(
+          logger.info(
             { err: error, client_id: client.id, project_id, user_id },
             "silently ignoring unauthorized updateClientPosition. Client likely hasn't called joinProject yet."
           )

--- a/test/acceptance/js/JoinProjectTests.js
+++ b/test/acceptance/js/JoinProjectTests.js
@@ -221,9 +221,7 @@ describe('joinProject', function () {
     })
 
     it('should return an error', function () {
-      this.error.message.should.equal(
-        'Something went wrong in real-time service'
-      )
+      this.error.message.should.equal('not authorized')
     })
 
     it('should not have joined the project room', function (done) {

--- a/test/acceptance/js/JoinProjectTests.js
+++ b/test/acceptance/js/JoinProjectTests.js
@@ -282,7 +282,7 @@ describe('joinProject', function () {
     })
 
     it('should return an error', function () {
-      this.error.message.should.equal('Something went wrong in real-time service')
+      this.error.code.should.equal('ProjectNotFound')
     })
 
     it('should not have joined the project room', function (done) {

--- a/test/acceptance/js/JoinProjectTests.js
+++ b/test/acceptance/js/JoinProjectTests.js
@@ -237,6 +237,67 @@ describe('joinProject', function () {
     })
   })
 
+  describe('when deleted and web replies with a 404', function () {
+    before(function (done) {
+      return async.series(
+        [
+          (cb) => {
+            return FixturesManager.setUpProject(
+              {
+                project_id: 'not-found',
+                privilegeLevel: 'owner',
+                project: {
+                  name: 'Test Project'
+                }
+              },
+              (e, { project_id, user_id }) => {
+                this.project_id = project_id
+                this.user_id = user_id
+                cb(e)
+              }
+            )
+          },
+
+          (cb) => {
+            this.client = RealTimeClient.connect()
+            this.client.on('connectionAccepted', cb)
+          },
+
+          (cb) => {
+            this.client.emit(
+              'joinProject',
+              { project_id: this.project_id },
+              (error, project, privilegeLevel, protocolVersion) => {
+                this.error = error
+                this.project = project
+                this.privilegeLevel = privilegeLevel
+                this.protocolVersion = protocolVersion
+                cb()
+              }
+            )
+          }
+        ],
+        done
+      )
+    })
+
+    it('should return an error', function () {
+      this.error.message.should.equal('Something went wrong in real-time service')
+    })
+
+    it('should not have joined the project room', function (done) {
+      RealTimeClient.getConnectedClient(
+        this.client.socket.sessionid,
+        (error, client) => {
+          expect(Array.from(client.rooms).includes(this.project_id)).to.equal(
+            false
+          )
+          done()
+        }
+      )
+    })
+  })
+
   return describe('when over rate limit', function () {
     before(function (done) {
       return async.series(

--- a/test/acceptance/js/JoinProjectTests.js
+++ b/test/acceptance/js/JoinProjectTests.js
@@ -176,6 +176,69 @@ describe('joinProject', function () {
     })
   })
 
+  describe('when not authorized and web replies with a 403', function () {
+    before(function (done) {
+      return async.series(
+        [
+          (cb) => {
+            return FixturesManager.setUpProject(
+              {
+                project_id: 'forbidden',
+                privilegeLevel: 'owner',
+                project: {
+                  name: 'Test Project'
+                }
+              },
+              (e, { project_id, user_id }) => {
+                this.project_id = project_id
+                this.user_id = user_id
+                cb(e)
+              }
+            )
+          },
+
+          (cb) => {
+            this.client = RealTimeClient.connect()
+            this.client.on('connectionAccepted', cb)
+          },
+
+          (cb) => {
+            this.client.emit(
+              'joinProject',
+              { project_id: this.project_id },
+              (error, project, privilegeLevel, protocolVersion) => {
+                this.error = error
+                this.project = project
+                this.privilegeLevel = privilegeLevel
+                this.protocolVersion = protocolVersion
+                cb()
+              }
+            )
+          }
+        ],
+        done
+      )
+    })
+
+    it('should return an error', function () {
+      this.error.message.should.equal(
+        'Something went wrong in real-time service'
+      )
+    })
+
+    it('should not have joined the project room', function (done) {
+      RealTimeClient.getConnectedClient(
+        this.client.socket.sessionid,
+        (error, client) => {
+          expect(Array.from(client.rooms).includes(this.project_id)).to.equal(
+            false
+          )
+          done()
+        }
+      )
+    })
+  })
+
   return describe('when over rate limit', function () {
     before(function (done) {
       return async.series(

--- a/test/acceptance/js/helpers/MockWebServer.js
+++ b/test/acceptance/js/helpers/MockWebServer.js
@@ -38,6 +38,9 @@ module.exports = MockWebServer = {
   joinProjectRequest(req, res, next) {
     const { project_id } = req.params
     const { user_id } = req.query
+    if (project_id === 'forbidden') {
+      return res.status(403).send()
+    }
     if (project_id === 'rate-limited') {
       return res.status(429).send()
     } else {

--- a/test/acceptance/js/helpers/MockWebServer.js
+++ b/test/acceptance/js/helpers/MockWebServer.js
@@ -38,6 +38,9 @@ module.exports = MockWebServer = {
   joinProjectRequest(req, res, next) {
     const { project_id } = req.params
     const { user_id } = req.query
+    if (project_id === 'not-found') {
+      return res.status(404).send()
+    }
     if (project_id === 'forbidden') {
       return res.status(403).send()
     }

--- a/test/unit/js/WebApiManagerTests.js
+++ b/test/unit/js/WebApiManagerTests.js
@@ -107,8 +107,7 @@ describe('WebApiManager', function () {
         this.callback
           .calledWith(
             sinon.match({
-              message: 'non-success status code from web',
-              info: { statusCode: 403 }
+              message: 'not authorized'
             })
           )
           .should.equal(true)

--- a/test/unit/js/WebApiManagerTests.js
+++ b/test/unit/js/WebApiManagerTests.js
@@ -91,6 +91,30 @@ describe('WebApiManager', function () {
       })
     })
 
+    describe('when web replies with a 403', function () {
+      beforeEach(function () {
+        this.request.post = sinon
+          .stub()
+          .callsArgWith(1, null, { statusCode: 403 }, null)
+        this.WebApiManager.joinProject(
+          this.project_id,
+          this.user_id,
+          this.callback
+        )
+      })
+
+      it('should call the callback with an error', function () {
+        this.callback
+          .calledWith(
+            sinon.match({
+              message: 'non-success status code from web',
+              info: { statusCode: 403 }
+            })
+          )
+          .should.equal(true)
+      })
+    })
+
     describe('with an error from web', function () {
       beforeEach(function () {
         this.request.post = sinon

--- a/test/unit/js/WebApiManagerTests.js
+++ b/test/unit/js/WebApiManagerTests.js
@@ -130,8 +130,8 @@ describe('WebApiManager', function () {
         this.callback
           .calledWith(
             sinon.match({
-              message: 'non-success status code from web',
-              info: { statusCode: 404 }
+              message: 'project not found',
+              info: { code: 'ProjectNotFound' }
             })
           )
           .should.equal(true)

--- a/test/unit/js/WebApiManagerTests.js
+++ b/test/unit/js/WebApiManagerTests.js
@@ -114,6 +114,30 @@ describe('WebApiManager', function () {
       })
     })
 
+    describe('when web replies with a 404', function () {
+      beforeEach(function () {
+        this.request.post = sinon
+          .stub()
+          .callsArgWith(1, null, { statusCode: 404 }, null)
+        this.WebApiManager.joinProject(
+          this.project_id,
+          this.user_id,
+          this.callback
+        )
+      })
+
+      it('should call the callback with an error', function () {
+        this.callback
+          .calledWith(
+            sinon.match({
+              message: 'non-success status code from web',
+              info: { statusCode: 404 }
+            })
+          )
+          .should.equal(true)
+      })
+    })
+
     describe('with an error from web', function () {
       beforeEach(function () {
         this.request.post = sinon


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3265

One of the last steps for the reworked logging is a re-leveling of error log messages. Specifically those that are _expected_ and hence should not trigger a server-error/sentry issue (level error and above).

Changing the 403 handling is already covered by the frontend.

> Users will get redirected to the login page and will see a 'restricted'
> page after logging in again.
> See frontend: ConnectionManager.reportConnectionError

Changing the 404 handling uses https://github.com/overleaf/web-internal/pull/3143 for a nicer UX (exiting the broken editor).

There is only the [socket.io logging left now](https://console.cloud.google.com/logs/viewer?project=mgcp-1117973-ol-prod&organizationId=753464038511&minLogLevel=0&expandAll=false&timestamp=2020-08-27T11:09:51.935000000Z&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Fol-gke-02%2Fnamespace_name%2Fdefault%2Fcontainer_name%2Freal-time-blue&scrollTimestamp=2020-08-27T10:15:13.603368337Z&advancedFilter=resource.type%3D%22k8s_container%22%0Aresource.labels.cluster_name%3D%22ol-gke-02%22%0Aresource.labels.namespace_name%3D%22default%22%0Aresource.labels.container_name%3D%22real-time-blue%22%0ANOT%20%22updateClientPosition%22%20AND%20NOT%20%22not%20authorized%22%20AND%20NOT%20%22doc%20updater%20could%20not%20load%20requested%20ops%22%20AND%20NOT%20%22no%20project_id%20found%20on%20client%22%20AND%20NOT%20%22joinLeaveEpoch%20mismatch%22%20AND%20NOT%20%22could%20not%20look%20up%20session%20by%20key%22%20AND%20NOT%20%22error%20from%20document%20updater,%20disconnecting%20client%22%20AND%20NOT%20%22attempted%20to%20write%20to%20disconnected%20client%22%20AND%20NOT%20%22rate-limit%20hit%20when%20joining%20project%22%20AND%20NOT%20%22slow%20event%20loop%22%20AND%20NOT%20%22non-success%20status%20code%20from%20web%22&dateRangeEnd=2020-08-27T11:09:13.425Z&dateRangeUnbound=backwardInTime): https://github.com/overleaf/issues/issues/3373

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3265

### Review

`Router._handleError` is tracking the rpc method now -- previously only the server errors included this detail (and the `unexpected-arguments` metric). This may aid debugging/log searching -- e.g. filter errors by rpc method.

#### Potential Impact

Low. Affects error paths for unauthorized/stale requests.

#### Manual Testing Performed

Added acceptance tests.

- checkout https://github.com/overleaf/web-internal/pull/3143
- open a project in the editor in dev-env
- delete the project in a second browser tab, then confirm the deletion in the trashed project section
- restart real-time (to trigger a joinProject rpc call)
- eventually the page reloads and a 'Not Found'  page is rendered.

#### Deployment Checklist

- [ ] merge https://github.com/overleaf/web-internal/pull/3143

