### PR TITLE
[misc] socket.io: use a custom logger

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,11 +23,26 @@ const CookieParser = require('cookie-parser')
 const DrainManager = require('./app/js/DrainManager')
 const HealthCheckManager = require('./app/js/HealthCheckManager')
 
+// NOTE: debug is invoked for every blob that is put on the wire
+const socketIoLogger = {
+  error(...message) {
+    logger.info({ fromSocketIo: true, originalLevel: 'error' }, ...message)
+  },
+  warn(...message) {
+    logger.info({ fromSocketIo: true, originalLevel: 'warn' }, ...message)
+  },
+  info() {},
+  debug() {},
+  log() {}
+}
+
 // Set up socket.io server
 const app = express()
 
 const server = require('http').createServer(app)
-const io = require('socket.io').listen(server)
+const io = require('socket.io').listen(server, {
+  logger: socketIoLogger
+})
 
 // Bind to sessions
 const sessionStore = new RedisStore({ client: sessionRedisClient })
@@ -61,7 +76,6 @@ io.configure(function () {
     'xhr-polling',
     'jsonp-polling'
   ])
-  io.set('log level', 1)
 })
 
 app.get('/', (req, res) => res.send('real-time-sharelatex is alive'))


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3373

We are seeing lots of useless log messages from socket.io. Mostly related to bad requests.

This PR is implementing a custom logger for socket.io -- as a replacement for [the built-in logger](https://github.com/overleaf/socket.io/blob/0b7ed64082542638ab1d7d01decb5c3bf46275a0/lib/logger.js) which emits using [console.log](https://github.com/overleaf/socket.io/blob/0b7ed64082542638ab1d7d01decb5c3bf46275a0/lib/logger.js#L78-L84) (which is slow and blocking).
- forward the previously enabled log messages to our logger-module
- stub the previously disabled logger methods
- drop the log-level config for socket.io


#### Review

All logs are sent to the INFO level and get a context of `{ fromSocketIo: true, originalLevel: level }` in case we want to filter logs.

#### Related Issues / PRs

For https://github.com/overleaf/issues/issues/3373

#### Potential Impact

High. All of socket.io is calling the logger methods.

#### Manual Testing Performed

- happy path
  - editor works
  - no log messages are emitted

- error logging:
  - create an invalid socket.io websocket request:
    `$ curl http://127.0.0.1:3026/socket.io/1/websocket/asdf -H 'Connection: upgrade'`
  - see a log message on level info
    `{"name":"real-time","hostname":"9bea99b0bcc6","pid":18,"level":30,"fromSocketIo":true,"originalLevel":"warn","msg":"websocket connection invalid","time":"2020-08-28T10:52:55.055Z","v":0}`

