### PR TITLE
[app] ignore error from writing to disconnected long-polling client

### DIFF
--- a/app.js
+++ b/app.js
@@ -220,9 +220,13 @@ if (Settings.shutdownDrainTimeWindow) {
     process.removeAllListeners('uncaughtException')
     process.on('uncaughtException', function (error) {
       if (
-        ['ETIMEDOUT', 'EHOSTUNREACH', 'EPIPE', 'ECONNRESET'].includes(
-          error.code
-        )
+        [
+          'ETIMEDOUT',
+          'EHOSTUNREACH',
+          'EPIPE',
+          'ECONNRESET',
+          'ERR_STREAM_WRITE_AFTER_END'
+        ].includes(error.code)
       ) {
         Metrics.inc('disconnected_write', 1, { status: error.code })
         return logger.warn(


### PR DESCRIPTION
### Description

For https://digital-science.slack.com/archives/G6Q45PYQL/p1600778032002300


#### Related Issues / PRs

Previous swallow: #178 

#### Potential Impact

Low. This may turn a previous crash behavior into a memory leak.

#### Manual Testing Performed

Edge case -- it is unknown where and how to trigger it yet.