### PR TITLE
[misc] bump the dev-env to 3.3.5 -- drop custom unit test timeout

### DIFF
--- a/buildscript.txt
+++ b/buildscript.txt
@@ -5,4 +5,4 @@ real-time
 --env-pass-through=
 --node-version=10.22.1
 --public-repo=True
---script-version=3.3.4
+--script-version=3.3.5

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "node $NODE_APP_OPTIONS app.js",
     "test:acceptance:_run": "mocha --recursive --reporter spec --timeout 15000 --exit $@ test/acceptance/js",
     "test:acceptance": "npm run test:acceptance:_run -- --grep=$MOCHA_GREP",
-    "test:unit:_run": "mocha --recursive --reporter spec --timeout 5000 $@ test/unit/js",
+    "test:unit:_run": "mocha --recursive --reporter spec $@ test/unit/js",
     "test:unit": "npm run test:unit:_run -- --grep=$MOCHA_GREP",
     "nodemon": "nodemon --config nodemon.json",
     "lint": "node_modules/.bin/eslint --max-warnings 0 .",


### PR DESCRIPTION
### Description

For https://github.com/overleaf/issues/issues/3529

Reset the custom unit test timeout of 5s back to 2s.

#### Related Issues / PRs

Effectively revert #183 

#### Potential Impact

Low. Affects running unit tests only.
