### PR TITLE
[RoomManager] drop duplicate joining of entities

### DIFF
--- a/app/js/RoomManager.js
+++ b/app/js/RoomManager.js
@@ -85,7 +85,6 @@ module.exports = {
         { client: client.id, entity, id, beforeCount },
         'client joined existing room'
       )
-      client.join(id)
       callback()
     }
   },


### PR DESCRIPTION
### Description

Backport https://github.com/overleaf/real-time/pull/79 from v2

> #67 moved the client join out of the branch for empty rooms. Unfortunately the join in the branch for already present clients was not removed.

This duplicate join is harm-less at this time but very confusing.

#### Review

The actioned join is in line 63.

#### Related Issues / PRs

#79

#### Potential Impact

Low.
