### PR TITLE
[misc] explicitly install underscore

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "request": "^2.88.2",
     "settings-sharelatex": "^1.1.0",
     "socket.io": "https://github.com/overleaf/socket.io/archive/0.9.19-overleaf-4.tar.gz",
-    "socket.io-client": "https://github.com/overleaf/socket.io-client/archive/0.9.17-overleaf-3.tar.gz"
+    "socket.io-client": "https://github.com/overleaf/socket.io-client/archive/0.9.17-overleaf-3.tar.gz",
+    "underscore": "1.7.0"
   },
   "devDependencies": {
     "bunyan": "~0.22.3",


### PR DESCRIPTION
### Description

We are using `underscore` in `DocumentUpdaterManager` but do not specify an explicit dependency on it. We are implicitly using the `underscore` package of the redis module. Their dependency on `underscore` is removed in v2.

This PR is installing the existing package explicitly. This is separated from the upgrade PR to ease it's review.

https://github.com/overleaf/real-time/blob/b5d5a76555135cc827c2b3092c4cadc8cddad8bd/app/js/DocumentUpdaterManager.js#L5
https://github.com/overleaf/real-time/blob/b5d5a76555135cc827c2b3092c4cadc8cddad8bd/app/js/DocumentUpdaterManager.js#L101

#### Related Issues / PRs

Slightly related to https://github.com/overleaf/issues/issues/3650

### Review

Use the same (outdated) version that is already in place.

#### Potential Impact

Low. Only package.json entries.

#### Manual Testing Performed

- test together with the redis upgrade in staging.
