### PR TITLE
add comment about health checks on '/'

### DIFF
--- a/app.js
+++ b/app.js
@@ -78,6 +78,7 @@ io.configure(function () {
   ])
 })
 
+// a 200 response on '/' is required for load balancer health checks
 app.get('/', (req, res) => res.send('real-time-sharelatex is alive'))
 
 app.get('/status', function (req, res) {


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Added comment about load balancer health checks requiring a 200 response on '/' for real-time.

We already support this with an `app.get('/', (req, res) => res.send('real-time-sharelatex is alive'))` , but I've added a comment so nobody will think this endpoint is redundant and removes it.

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/3402#issuecomment-734865623
https://github.com/overleaf/web-internal/pull/3421

### Review

Comment only

#### Potential Impact

None

#### Manual Testing Performed

- [X] CI tests

#### Accessibility

NA

### Deployment

NA

#### Deployment Checklist

NA

#### Metrics and Monitoring

NA

#### Who Needs to Know?

cc @henryoswald 