### PR TITLE
[misc] let mocha catch errors when running acceptance tests

### DIFF
--- a/config/settings.test.js
+++ b/config/settings.test.js
@@ -1,0 +1,5 @@
+module.exports = {
+  errors: {
+    catchUncaughtErrors: false
+  }
+}


### PR DESCRIPTION
### Description

Additional fix to #207 

The mocha run was seemingly not failing even tho some assertions failed. The root cause for the assertions has been addressed in #207 and the PR is addressing the false positive test success.

In production we are attaching an event listener for unhandled exceptions and then shutdown the app. This handler must not run when mocha attaches their own handler.

Note: tests are failing and should fail without the patch in #207. To be rebased onto #207 after it lands.

#### Related Issues / PRs

#207

#### Potential Impact

High. Not attaching the exception handler in production would be fatal. To be tested.

#### Manual Testing Performed

- [ ] test in staging

#### Deployment Checklist

- [ ] Test in staging: trigger exception or send process signal

#### Who Needs to Know?

@henryoswald 