### PR TITLE
add blue-green deployment support with load-balancer health-checks

### DIFF
--- a/app.js
+++ b/app.js
@@ -85,7 +85,7 @@ io.configure(function () {
 // a 200 response on '/' is required for load balancer health checks
 // these operate separately from kubernetes readiness checks
 app.get('/', function (req, res) {
-  if (Settings.serviceIsClosed || Settings.shutDownInProgress) {
+  if (Settings.shutDownInProgress || DeploymentManager.deploymentIsClosed()) {
     res.sendStatus(503) // Service unavailable
   } else {
     res.send('real-time is open')

--- a/app/js/DeploymentManager.js
+++ b/app/js/DeploymentManager.js
@@ -12,7 +12,7 @@ const deploymentColour = settings.deploymentColour
 var serviceCloseTime
 
 function updateDeploymentStatus(fileContent) {
-  const closed = fileContent && fileContent.indexOf(deploymentColour) === -1
+  const closed = fileContent && !fileContent.includes(deploymentColour)
   if (closed && !settings.serviceIsClosed) {
     settings.serviceIsClosed = true
     serviceCloseTime = Date.now() + 60 * 1000 // delay closing by 1 minute

--- a/app/js/DeploymentManager.js
+++ b/app/js/DeploymentManager.js
@@ -9,10 +9,13 @@ const FILE_CHECK_INTERVAL = 5000
 const statusFile = settings.deploymentFile
 const deploymentColour = settings.deploymentColour
 
+var serviceCloseTime
+
 function updateDeploymentStatus(fileContent) {
   const closed = fileContent && fileContent.indexOf(deploymentColour) === -1
   if (closed && !settings.serviceIsClosed) {
     settings.serviceIsClosed = true
+    serviceCloseTime = Date.now() + 60 * 1000 // delay closing by 1 minute
     logger.warn({ fileContent }, 'closing service')
   } else if (!closed && settings.serviceIsClosed) {
     settings.serviceIsClosed = false
@@ -49,5 +52,8 @@ module.exports = {
       checkStatusFileSync() // perform an initial synchronous check at start up
       setInterval(pollStatusFile, FILE_CHECK_INTERVAL) // continue checking periodically
     }
+  },
+  deploymentIsClosed() {
+    return settings.serviceIsClosed && Date.now() > serviceCloseTime
   }
 }

--- a/config/settings.defaults.js
+++ b/config/settings.defaults.js
@@ -148,6 +148,12 @@ const settings = {
 
   statusCheckInterval: parseInt(process.env.STATUS_CHECK_INTERVAL || '0'),
 
+  // The deployment colour for this app (if any). Used for blue green deploys.
+  deploymentColour: process.env.DEPLOYMENT_COLOUR,
+  // Load balancer health checks will return 200 only when this file contains
+  // the deployment colour for this app.
+  deploymentFile: process.env.DEPLOYMENT_FILE,
+
   sentry: {
     dsn: process.env.SENTRY_DSN
   },


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

This PR allows real-time to use blue-green deployments behind a load-balancer.

To avoid problems with changes to kubernetes services (which can cause downtime) and changes to pod labels (which can revert if a node or pod is recreated) this uses a configmap to allow the real-time pods to signal to the load balancer whether they are available.

The configmap  specifies the current `deployment_colour`, and the pods monitor it via a file.  The  pod colour is defined via an environment variable at start up.  When the pod colour matches the `deployment_colour` then the pod signals to the load balancer that it is available through the load balancer health checks on `/`, otherwise it removes itself from the load balancer by returning `503 Unavailable` on `/`.

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/google-ops/pull/1516
https://github.com/overleaf/google-ops/pull/1534

### Review

The open/close mechanism for the blue green flipping is independent of the pod shutdown.  We are essentially recreating the service flip at the pod level.  Configmaps can take up to a minute to update, so to ensure the changeover is graceful I've added a 1 minute delay before old pods are closed.  The opening is immediate.

#### Potential Impact

Real-time connections

#### Manual Testing Performed

- [X]  Test in dev env (Add settings for deployment file and colour to docker config, modify an existing file in the container to change the colour, I used /etc/issue, monitor the load balancer health check on / and see that closing takes 1 minute and opening is immediate).
 
#### Accessibility

NA

### Deployment

Deploy the changes to create the configmap first: 
- [ ] https://github.com/overleaf/google-ops/pull/1516
- [ ] https://github.com/overleaf/google-ops/pull/1534

#### Deployment Checklist

- 

#### Metrics and Monitoring

Realtime connections

#### Who Needs to Know?

