### PR TITLE
Lower log level of 'no project_id found on client' messages

### DIFF
--- a/app/js/Router.js
+++ b/app/js/Router.js
@@ -44,12 +44,15 @@ module.exports = Router = {
       metrics.inc('unexpected-arguments', 1, { status: method })
       const serializedError = { message: error.message }
       callback(serializedError)
+    } else if (error.message === 'no project_id found on client') {
+      logger.debug(attrs, error.message)
+      const serializedError = { message: error.message }
+      callback(serializedError)
     } else if (
       [
         'not authorized',
         'joinLeaveEpoch mismatch',
-        'doc updater could not load requested ops',
-        'no project_id found on client'
+        'doc updater could not load requested ops'
       ].includes(error.message)
     ) {
       logger.warn(attrs, error.message)


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

Reduce log noise by lowering log level of `no project_id found on client` messages.

#### Related Issues / PRs

Papercut 32