### PR TITLE
add transport type to real-time metrics

### DIFF
--- a/app/js/Router.js
+++ b/app/js/Router.js
@@ -153,7 +153,7 @@ module.exports = Router = {
       client.publicId = 'P.' + base64id.generateId()
       client.emit('connectionAccepted', null, client.publicId)
 
-      metrics.inc('socket-io.connection')
+      metrics.inc('socket-io.connection', 1, { status: client.transport })
       metrics.gauge('socket-io.clients', io.sockets.clients().length)
 
       logger.log({ session, client_id: client.id }, 'client connected')
@@ -211,7 +211,7 @@ module.exports = Router = {
       })
 
       client.on('disconnect', function () {
-        metrics.inc('socket-io.disconnect')
+        metrics.inc('socket-io.disconnect', 1, { status: client.transport })
         metrics.gauge('socket-io.clients', io.sockets.clients().length)
 
         WebsocketController.leaveProject(io, client, function (err) {

--- a/app/js/WebsocketController.js
+++ b/app/js/WebsocketController.js
@@ -36,7 +36,7 @@ module.exports = WebsocketController = {
       { user_id, project_id, client_id: client.id },
       'user joining project'
     )
-    metrics.inc('editor.join-project')
+    metrics.inc('editor.join-project', 1, { status: client.transport })
     WebApiManager.joinProject(project_id, user, function (
       error,
       project,
@@ -114,7 +114,7 @@ module.exports = WebsocketController = {
       return callback()
     } // client did not join project
 
-    metrics.inc('editor.leave-project')
+    metrics.inc('editor.leave-project', 1, { status: client.transport })
     logger.log(
       { project_id, user_id, client_id: client.id },
       'client leaving project'
@@ -167,7 +167,7 @@ module.exports = WebsocketController = {
     }
 
     const joinLeaveEpoch = ++client.joinLeaveEpoch
-    metrics.inc('editor.join-doc')
+    metrics.inc('editor.join-doc', 1, { status: client.transport })
     const { project_id, user_id, is_restricted_user } = client.ol_context
     if (!project_id) {
       return callback(new NotJoinedError())
@@ -319,7 +319,7 @@ module.exports = WebsocketController = {
   leaveDoc(client, doc_id, callback) {
     // client may have disconnected, but we have to cleanup internal state.
     client.joinLeaveEpoch++
-    metrics.inc('editor.leave-doc')
+    metrics.inc('editor.leave-doc', 1, { status: client.transport })
     const { project_id, user_id } = client.ol_context
     logger.log(
       { user_id, project_id, doc_id, client_id: client.id },
@@ -338,7 +338,9 @@ module.exports = WebsocketController = {
       return callback()
     }
 
-    metrics.inc('editor.update-client-position', 0.1)
+    metrics.inc('editor.update-client-position', 0.1, {
+      status: client.transport
+    })
     const {
       project_id,
       first_name,
@@ -475,7 +477,7 @@ module.exports = WebsocketController = {
         }
         update.meta.source = client.publicId
         update.meta.user_id = user_id
-        metrics.inc('editor.doc-update', 0.3)
+        metrics.inc('editor.doc-update', 0.3, { status: client.transport })
 
         logger.log(
           {

--- a/app/js/WebsocketController.js
+++ b/app/js/WebsocketController.js
@@ -414,7 +414,7 @@ module.exports = WebsocketController = {
       return callback()
     }
 
-    metrics.inc('editor.get-connected-users')
+    metrics.inc('editor.get-connected-users', { status: client.transport })
     const { project_id, user_id, is_restricted_user } = client.ol_context
     if (is_restricted_user) {
       return callback(null, [])


### PR DESCRIPTION
<!-- ** This is an Overleaf public repository ** -->

<!-- Please review https://github.com/overleaf/overleaf/blob/master/CONTRIBUTING.md for guidance on what is expected of a contribution. -->

### Description

This PR adds the socket.io `transport` type to the main metrics in real-time, so we can see how many clients are connecting via websockets vs xhr-polling.  Currently we don't have this information, so we have been flying blind with the Chrome "websockets over HTTP/2" bug (https://bugs.chromium.org/p/chromium/issues/detail?id=801564).

#### Screenshots

NA

#### Related Issues / PRs

https://github.com/overleaf/issues/issues/4293

### Review

Uses the existing `status` label with `client.transport`.

#### Potential Impact

Metrics only.

#### Manual Testing Performed

- [X] Test in local dev environment


#### Accessibility

NA

### Deployment


- [ ] `rake deploy:app[staging,real-time,master,latest]`
- [ ] `rake deploy:app[production,real-time,master,latest]`

#### Deployment Checklist

- [ ] Check metrics with curl

#### Metrics and Monitoring

- [ ] Update real-time dashboard to show transport breakdown

#### Who Needs to Know?

cc @gh2k @henryoswald 